### PR TITLE
Add unified polygonal tundra parameterization option

### DIFF
--- a/runcase.py
+++ b/runcase.py
@@ -955,6 +955,13 @@ parser.add_option(
     action="store_true",
 )
 parser.add_option(
+    "--unified_polygonal_tundra",
+    dest="unified_polygonal_tundra",
+    default=False,
+    help="Use unified polygonal tundra parameterization across all topounits",
+    action="store_true",
+)
+parser.add_option(
     "--use_arctic_init",
     dest="use_arctic_init",
     default=False,
@@ -1359,7 +1366,7 @@ mysimyr = 1850
 #    #note - spinup with 2000 conditions for FATES
 #    mysimyr=2000
 
-if options.nopointdata == False:
+if not options.nopointdata:
     ptcmd = (
         "python makepointdata.py --ccsm_input "
         + options.ccsm_input
@@ -2526,6 +2533,11 @@ for i in range(1, int(options.ninst) + 1):
     # NGEE Arctic IM1
     if options.use_polygonal_tundra:
         output.write(" use_polygonal_tundra = .true.\n")
+        if options.unified_polygonal_tundra:
+            output.write(" unified_polygonal_tundra = .true.\n")
+    if options.unified_polygonal_tundra and not options.use_polygonal_tundra: 
+        print("Error:  unified_polygonal_tundra option requires use_polygonal_tundra to be set.  Aborting")
+        sys.exit(1)
     if options.use_arctic_init:
         output.write(" use_arctic_init = .true.\n")
     # NGEE Arctic IM2
@@ -2950,7 +2962,7 @@ if cpl_bypass:
 #copy sourcemods
 os.chdir('..')
 if (options.srcmods_loc != ''):
-    if (os.path.exists(options.srcmods_loc) == False):
+    if (not os.path.exists(options.srcmods_loc)):
         print('Invalid srcmods directory.  Exiting')
         sys.exit(1)
     options.srcmods_loc = os.path.abspath(options.srcmods_loc)
@@ -2965,7 +2977,7 @@ runcmd('mkdir -p Srcfiles', check=False)
 if (options.clean_build):
     runcmd('./case.build --clean', check=False)
 #compile model
-if (options.no_build == False):
+if (not options.no_build):
     print('Running case.build')
     runcmd('./case.build')
 else:
@@ -3110,7 +3122,7 @@ if not cpl_bypass and not isglobal:
         myoutput.close()
 
     # reverse directories for CLM1PT and site
-    if options.cruncep == False:
+    if not options.cruncep:
         myinput = open(
             "./Buildconf/datmconf/datm.streams.txt.CLM1PT." + mylsm + "_USRDAT"
         )
@@ -3147,7 +3159,7 @@ if options.domainfile == "":
     runcmd("cp " + PTCLMdir + "/temp/domain.nc " + runroot + "/" + casename + "/run/")
 if options.surffile == "":
     runcmd("cp " + PTCLMdir + "/temp/surfdata.nc " + runroot + "/" + casename + "/run/")
-if "20TR" in compset and options.nopftdyn == False and options.pftdynfile == "":
+if "20TR" in compset and not options.nopftdyn and options.pftdynfile == "":
     runcmd(
         "cp "
         + PTCLMdir
@@ -3160,7 +3172,7 @@ if "20TR" in compset and options.nopftdyn == False and options.pftdynfile == "":
 
 # submit job if requested
 if (
-    options.no_submit == False
+    not options.no_submit
     and int(options.mc_ensemble) < 0
     and options.ensemble_file == ""
 ):
@@ -3318,7 +3330,7 @@ if (options.ensemble_file != "" or int(options.mc_ensemble) != -1) and (
         output_run.write(cmd+'\n')
         output_run.close()
 
-        if options.no_submit == False:
+        if not options.no_submit:
             runcmd(
                 mysubmit_type
                 + " "

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -483,6 +483,13 @@ parser.add_option(
     help="Turn on the polygonal tundra parameterizations, NGEE Arctic Phase 3 IM1",
     action="store_true",
 )
+parser.add_option(
+    "--unified_polygonal_tundra",
+    dest="unified_polygonal_tundra",
+    default=False,
+    help="Use unified polygonal tundra parameterization across all topounits",
+    action="store_true",
+)
 # cold initialization:
 parser.add_option(
     "--use_arctic_init",
@@ -1060,6 +1067,8 @@ for row in AFdatareader:
         # polygonal tundra
         if options.use_polygonal_tundra:
             basecmd = basecmd + " --use_polygonal_tundra"
+        if options.unified_polygonal_tundra:
+            basecmd = basecmd + " --unified_polygonal_tundra"
         if options.use_arctic_init:
             basecmd = basecmd + " --use_arctic_init"
         # Arctic hillslope hydrology


### PR DESCRIPTION
- Adds `--unified_polygonal_tundra` flag to `runcase.py` and `site_fullrun.py`, which sets `unified_polygonal_tundra = .true.` in the ELM namelist. This option applies the polygonal tundra parameterization uniformly across all topounits and requires `--use_polygonal_tundra` to also be set (enforced with an error check).                                        
- Applied ruff formatting across all Python scripts (no logic changes). 