### PR TITLE
Fix silent failures in CI

### DIFF
--- a/.github/workflows/site-full-run.ci.yml
+++ b/.github/workflows/site-full-run.ci.yml
@@ -122,11 +122,12 @@ jobs:
             # Execute the command
             eval $DOCKER_CMD
 
-        - name: Upload ${{ matrix.simulation }} logs on failure
-          if: failure()
+        - name: Upload ${{ matrix.simulation }} logs
+          if: always()
           uses: actions/upload-artifact@v7
           with:
             name: ${{ matrix.simulation }}-case-logs
+            retention-days: 1
             path: |
               ${{ github.workspace }}/output/**/bld/*.bldlog.*
               ${{ github.workspace }}/output/**/run/*.log.*

--- a/.github/workflows/site-full-run.ci.yml
+++ b/.github/workflows/site-full-run.ci.yml
@@ -116,6 +116,9 @@ jobs:
             # Add spinup and transient years
             DOCKER_CMD="$DOCKER_CMD --nyears_ad_spinup 1 --nyears_final_spinup 1 --nyears_transient 1"
 
+            # Check the command
+            echo $DOCKER_CMD
+
             # Execute the command
             eval $DOCKER_CMD
 

--- a/.github/workflows/site-full-run.ci.yml
+++ b/.github/workflows/site-full-run.ci.yml
@@ -54,6 +54,7 @@ jobs:
 
         - name: Run test case for site
           run: |
+            set -e
             # ensure writable by current user
             chmod -R u+rwX .cache/inputdata || true
 
@@ -79,8 +80,18 @@ jobs:
               --ccsm_input /home/e3smuser/inputdata \
               --nyears_ad_spinup 1 --nyears_final_spinup 1 --nyears_transient 1
 
+        - name: Upload GSWP3 logs on failure
+          if: failure()
+          uses: actions/upload-artifact@v4
+          with:
+            name: gswp3-case-logs
+            path: |
+              ${{ github.workspace }}/output/**/bld/*.bldlog.*
+              ${{ github.workspace }}/output/**/run/*.log.*
+
         - name: Run ERA5 test for site
           run: |
+            set -e
             # ensure writable by current user
             chmod -R u+rwX .cache/inputdata || true
 
@@ -104,4 +115,14 @@ jobs:
               --model_root /home/e3smuser/E3SM \
               --runroot /home/e3smuser/output \
               --ccsm_input /home/e3smuser/inputdata \
+              --srcmods_loc /home/e3smuser/OLMT/srcmods_era5cb \
               --nyears_ad_spinup 1 --nyears_final_spinup 1 --nyears_transient 1
+
+        - name: Upload ERA5 logs on failure
+          if: failure()
+          uses: actions/upload-artifact@v4
+          with:
+            name: era5-case-logs
+            path: |
+              ${{ github.workspace }}/output/**/bld/*.bldlog.*
+              ${{ github.workspace }}/output/**/run/*.log.*

--- a/.github/workflows/site-full-run.ci.yml
+++ b/.github/workflows/site-full-run.ci.yml
@@ -13,7 +13,6 @@ on:
 
 jobs:
     test-site:
-      if: github.event_name != 'schedule'
       runs-on: ubuntu-latest
       strategy:
         fail-fast: false
@@ -76,6 +75,7 @@ jobs:
             cd field-to-model-inputdata
             git sparse-checkout init --cone
             git sparse-checkout set E3SM
+            find ${{ github.workspace }}/field-to-model-inputdata -name "*.gz" -exec gunzip -v {} +
 
         - name: Prepare output dir
           run: mkdir -p ${{ github.workspace }}/output
@@ -131,3 +131,4 @@ jobs:
             path: |
               ${{ github.workspace }}/output/**/bld/*.bldlog.*
               ${{ github.workspace }}/output/**/run/*.log.*
+              ${{ github.workspace }}/output/**/run/*_in    

--- a/.github/workflows/site-full-run.ci.yml
+++ b/.github/workflows/site-full-run.ci.yml
@@ -82,7 +82,7 @@ jobs:
 
         - name: Upload GSWP3 logs on failure
           if: failure()
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v5
           with:
             name: gswp3-case-logs
             path: |
@@ -120,7 +120,7 @@ jobs:
 
         - name: Upload ERA5 logs on failure
           if: failure()
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v5
           with:
             name: era5-case-logs
             path: |

--- a/.github/workflows/site-full-run.ci.yml
+++ b/.github/workflows/site-full-run.ci.yml
@@ -82,7 +82,7 @@ jobs:
 
         - name: Upload GSWP3 logs on failure
           if: failure()
-          uses: actions/upload-artifact@v5
+          uses: actions/upload-artifact@v7
           with:
             name: gswp3-case-logs
             path: |
@@ -120,7 +120,45 @@ jobs:
 
         - name: Upload ERA5 logs on failure
           if: failure()
-          uses: actions/upload-artifact@v5
+          uses: actions/upload-artifact@v7
+          with:
+            name: era5-case-logs
+            path: |
+              ${{ github.workspace }}/output/**/bld/*.bldlog.*
+              ${{ github.workspace }}/output/**/run/*.log.*
+
+        - name: Run ERA5-daymet4 test for site
+          run: |
+            set -e
+            # ensure writable by current user
+            chmod -R u+rwX .cache/inputdata || true
+
+            docker run --rm \
+              -v ${{ github.workspace }}/OLMT:/home/e3smuser/OLMT \
+              -v ${{ github.workspace }}/E3SM:/home/e3smuser/E3SM \
+              -v ${{ github.workspace }}/field-to-model-inputdata/E3SM:/home/e3smuser/inputdata \
+              -v ${{ github.workspace }}/output:/home/e3smuser/output \
+              -w /home/e3smuser/OLMT \
+              rfiorella/model-containers:e3sm-openmpi-dev-latest \
+              ./site_fullrun.py \
+              --machine docker \
+              --compiler gnu --mpilib openmpi \
+              --site AK-BEOG --sitegroup NGEEArctic \
+              --cpl_bypass --era5 --daymet4 \
+              --metdir /home/e3smuser/inputdata/atm/datm7/daymet4/utq \
+              --domainfile /home/e3smuser/inputdata/share/domains/domain.clm/domain.lnd.1x1pt_beo-GRID_navy.nc \
+              --surffile /home/e3smuser/inputdata/lnd/clm2/surfdata_map/surfdata_1x1pt_beo-GRID_simyr1850_c360x720_c171002.nc \
+              --landusefile /home/e3smuser/inputdata/lnd/clm2/surfdata_map/landuse.timeseries_1x1pt_beo-GRID_simyr1850-2015_c180423.nc \
+              --nofire --no_budgets --nopointdata \
+              --model_root /home/e3smuser/E3SM \
+              --runroot /home/e3smuser/output \
+              --ccsm_input /home/e3smuser/inputdata \
+              --srcmods_loc /home/e3smuser/OLMT/srcmods_era5cb \
+              --nyears_ad_spinup 1 --nyears_final_spinup 1 --nyears_transient 1
+
+        - name: Upload ERA5-daymet4 logs on failure
+          if: failure()
+          uses: actions/upload-artifact@v7
           with:
             name: era5-case-logs
             path: |

--- a/.github/workflows/site-full-run.ci.yml
+++ b/.github/workflows/site-full-run.ci.yml
@@ -15,6 +15,34 @@ jobs:
     test-site:
       if: github.event_name != 'schedule'
       runs-on: ubuntu-latest
+      strategy:
+        fail-fast: false
+        matrix:
+          include:
+            - simulation: gswp3
+              site: AK-SP-K64G
+              forcing_flags: --gswp3
+              metdir: /home/e3smuser/inputdata/atm/datm7/gswp3/kg
+              domainfile: /home/e3smuser/inputdata/share/domains/domain.clm/domain.lnd.1x1pt_kougarok-GRID_navy.nc
+              surffile: /home/e3smuser/inputdata/lnd/clm2/surfdata_map/surfdata_1x1pt_kougarok-GRID_simyr1850_c360x720_c171002.nc
+              landusefile: /home/e3smuser/inputdata/lnd/clm2/surfdata_map/landuse.timeseries_1x1pt_kougarok-GRID_simyr1850-2015_c180423.nc
+              srcmods_loc: ""
+            - simulation: era5
+              site: AK-BEOG
+              forcing_flags: --era5
+              metdir: /home/e3smuser/inputdata/atm/datm7/era5/utq
+              domainfile: /home/e3smuser/inputdata/share/domains/domain.clm/domain.lnd.1x1pt_beo-GRID_navy.nc
+              surffile: /home/e3smuser/inputdata/lnd/clm2/surfdata_map/surfdata_1x1pt_beo-GRID_simyr1850_c360x720_c171002.nc
+              landusefile: /home/e3smuser/inputdata/lnd/clm2/surfdata_map/landuse.timeseries_1x1pt_beo-GRID_simyr1850-2015_c180423.nc
+              srcmods_loc: /home/e3smuser/OLMT/srcmods_era5cb
+            - simulation: era5-daymet4
+              site: AK-BEOG
+              forcing_flags: --era5 --daymet4
+              metdir: /home/e3smuser/inputdata/atm/datm7/daymet4/utq
+              domainfile: /home/e3smuser/inputdata/share/domains/domain.clm/domain.lnd.1x1pt_beo-GRID_navy.nc
+              surffile: /home/e3smuser/inputdata/lnd/clm2/surfdata_map/surfdata_1x1pt_beo-GRID_simyr1850_c360x720_c171002.nc
+              landusefile: /home/e3smuser/inputdata/lnd/clm2/surfdata_map/landuse.timeseries_1x1pt_beo-GRID_simyr1850-2015_c180423.nc
+              srcmods_loc: /home/e3smuser/OLMT/srcmods_era5cb
       steps:
         - name: Checkout OLMT repo
           uses: actions/checkout@v6
@@ -52,13 +80,14 @@ jobs:
         - name: Prepare output dir
           run: mkdir -p ${{ github.workspace }}/output
 
-        - name: Run test case for site
+        - name: Run ${{ matrix.simulation }} test for site
           run: |
             set -e
             # ensure writable by current user
             chmod -R u+rwX .cache/inputdata || true
 
-            docker run --rm \
+            # Build docker command with conditional srcmods_loc
+            DOCKER_CMD="docker run --rm \
               -v ${{ github.workspace }}/OLMT:/home/e3smuser/OLMT \
               -v ${{ github.workspace }}/E3SM:/home/e3smuser/E3SM \
               -v ${{ github.workspace }}/field-to-model-inputdata/E3SM:/home/e3smuser/inputdata \
@@ -68,99 +97,33 @@ jobs:
               ./site_fullrun.py \
               --machine docker \
               --compiler gnu --mpilib openmpi \
-              --site AK-SP-K64G --sitegroup NGEEArctic \
-              --cpl_bypass --gswp3 \
-              --metdir /home/e3smuser/inputdata/atm/datm7/gswp3/kg \
-              --domainfile /home/e3smuser/inputdata/share/domains/domain.clm/domain.lnd.1x1pt_kougarok-GRID_navy.nc \
-              --surffile /home/e3smuser/inputdata/lnd/clm2/surfdata_map/surfdata_1x1pt_kougarok-GRID_simyr1850_c360x720_c171002.nc \
-              --landusefile /home/e3smuser/inputdata/lnd/clm2/surfdata_map/landuse.timeseries_1x1pt_kougarok-GRID_simyr1850-2015_c180423.nc \
+              --site ${{ matrix.site }} --sitegroup NGEEArctic \
+              --cpl_bypass ${{ matrix.forcing_flags }} \
+              --metdir ${{ matrix.metdir }} \
+              --domainfile ${{ matrix.domainfile }} \
+              --surffile ${{ matrix.surffile }} \
+              --landusefile ${{ matrix.landusefile }} \
               --nofire --no_budgets --nopointdata \
               --model_root /home/e3smuser/E3SM \
               --runroot /home/e3smuser/output \
-              --ccsm_input /home/e3smuser/inputdata \
-              --nyears_ad_spinup 1 --nyears_final_spinup 1 --nyears_transient 1
+              --ccsm_input /home/e3smuser/inputdata"
 
-        - name: Upload GSWP3 logs on failure
+            # Add srcmods_loc if specified
+            if [ -n "${{ matrix.srcmods_loc }}" ]; then
+              DOCKER_CMD="$DOCKER_CMD --srcmods_loc ${{ matrix.srcmods_loc }}"
+            fi
+
+            # Add spinup and transient years
+            DOCKER_CMD="$DOCKER_CMD --nyears_ad_spinup 1 --nyears_final_spinup 1 --nyears_transient 1"
+
+            # Execute the command
+            eval $DOCKER_CMD
+
+        - name: Upload ${{ matrix.simulation }} logs on failure
           if: failure()
           uses: actions/upload-artifact@v7
           with:
-            name: gswp3-case-logs
-            path: |
-              ${{ github.workspace }}/output/**/bld/*.bldlog.*
-              ${{ github.workspace }}/output/**/run/*.log.*
-
-        - name: Run ERA5 test for site
-          run: |
-            set -e
-            # ensure writable by current user
-            chmod -R u+rwX .cache/inputdata || true
-
-            docker run --rm \
-              -v ${{ github.workspace }}/OLMT:/home/e3smuser/OLMT \
-              -v ${{ github.workspace }}/E3SM:/home/e3smuser/E3SM \
-              -v ${{ github.workspace }}/field-to-model-inputdata/E3SM:/home/e3smuser/inputdata \
-              -v ${{ github.workspace }}/output:/home/e3smuser/output \
-              -w /home/e3smuser/OLMT \
-              rfiorella/model-containers:e3sm-openmpi-dev-latest \
-              ./site_fullrun.py \
-              --machine docker \
-              --compiler gnu --mpilib openmpi \
-              --site AK-BEOG --sitegroup NGEEArctic \
-              --cpl_bypass --era5 \
-              --metdir /home/e3smuser/inputdata/atm/datm7/era5/utq \
-              --domainfile /home/e3smuser/inputdata/share/domains/domain.clm/domain.lnd.1x1pt_beo-GRID_navy.nc \
-              --surffile /home/e3smuser/inputdata/lnd/clm2/surfdata_map/surfdata_1x1pt_beo-GRID_simyr1850_c360x720_c171002.nc \
-              --landusefile /home/e3smuser/inputdata/lnd/clm2/surfdata_map/landuse.timeseries_1x1pt_beo-GRID_simyr1850-2015_c180423.nc \
-              --nofire --no_budgets --nopointdata \
-              --model_root /home/e3smuser/E3SM \
-              --runroot /home/e3smuser/output \
-              --ccsm_input /home/e3smuser/inputdata \
-              --srcmods_loc /home/e3smuser/OLMT/srcmods_era5cb \
-              --nyears_ad_spinup 1 --nyears_final_spinup 1 --nyears_transient 1
-
-        - name: Upload ERA5 logs on failure
-          if: failure()
-          uses: actions/upload-artifact@v7
-          with:
-            name: era5-case-logs
-            path: |
-              ${{ github.workspace }}/output/**/bld/*.bldlog.*
-              ${{ github.workspace }}/output/**/run/*.log.*
-
-        - name: Run ERA5-daymet4 test for site
-          run: |
-            set -e
-            # ensure writable by current user
-            chmod -R u+rwX .cache/inputdata || true
-
-            docker run --rm \
-              -v ${{ github.workspace }}/OLMT:/home/e3smuser/OLMT \
-              -v ${{ github.workspace }}/E3SM:/home/e3smuser/E3SM \
-              -v ${{ github.workspace }}/field-to-model-inputdata/E3SM:/home/e3smuser/inputdata \
-              -v ${{ github.workspace }}/output:/home/e3smuser/output \
-              -w /home/e3smuser/OLMT \
-              rfiorella/model-containers:e3sm-openmpi-dev-latest \
-              ./site_fullrun.py \
-              --machine docker \
-              --compiler gnu --mpilib openmpi \
-              --site AK-BEOG --sitegroup NGEEArctic \
-              --cpl_bypass --era5 --daymet4 \
-              --metdir /home/e3smuser/inputdata/atm/datm7/daymet4/utq \
-              --domainfile /home/e3smuser/inputdata/share/domains/domain.clm/domain.lnd.1x1pt_beo-GRID_navy.nc \
-              --surffile /home/e3smuser/inputdata/lnd/clm2/surfdata_map/surfdata_1x1pt_beo-GRID_simyr1850_c360x720_c171002.nc \
-              --landusefile /home/e3smuser/inputdata/lnd/clm2/surfdata_map/landuse.timeseries_1x1pt_beo-GRID_simyr1850-2015_c180423.nc \
-              --nofire --no_budgets --nopointdata \
-              --model_root /home/e3smuser/E3SM \
-              --runroot /home/e3smuser/output \
-              --ccsm_input /home/e3smuser/inputdata \
-              --srcmods_loc /home/e3smuser/OLMT/srcmods_era5cb \
-              --nyears_ad_spinup 1 --nyears_final_spinup 1 --nyears_transient 1
-
-        - name: Upload ERA5-daymet4 logs on failure
-          if: failure()
-          uses: actions/upload-artifact@v7
-          with:
-            name: era5-case-logs
+            name: ${{ matrix.simulation }}-case-logs
             path: |
               ${{ github.workspace }}/output/**/bld/*.bldlog.*
               ${{ github.workspace }}/output/**/run/*.log.*

--- a/runcase.py
+++ b/runcase.py
@@ -45,7 +45,7 @@ def _parse_cmd(cmd_i):
     return result
 
 
-def runcmd(cmd, echo=True, tag=os.path.basename(__file__)):
+def runcmd(cmd, echo=True, check=True, tag=os.path.basename(__file__)):
     lineno = inspect.stack()[1].lineno
     cmd_log = cmd
     if any([x in cmd.split(" ")[0] for x in [".py", "newcase"]]):
@@ -54,7 +54,12 @@ def runcmd(cmd, echo=True, tag=os.path.basename(__file__)):
 
     if echo:
         print(cmd)
-    return os.system(cmd)
+    result = os.system(cmd)
+    if check and result != 0:
+        print("Error: command failed with exit status "
+              + str(result) + ": " + cmd)
+        sys.exit(1)
+    return result
 
 
 def chdir(path, echo=True, tag=os.path.basename(__file__)):
@@ -1299,11 +1304,11 @@ if os.path.exists(casedir):
     print("Warning:  Case directory exists")
     if options.rmold:
         print("--rmold specified.  Removing old case ")
-        runcmd("rm -rf " + casedir)
+        runcmd("rm -rf " + casedir, check=False)
     else:
         var = input("proceed (p), remove old (r), or exit (x)? ")
         if var[0] == "r":
-            runcmd("rm -rf " + casedir)
+            runcmd("rm -rf " + casedir, check=False)
         if var[0] == "x":
             sys.exit(1)
 print("CASE directory is: " + casedir)
@@ -1320,9 +1325,9 @@ print("CASE rundir is: " + rundir)
 if options.rmold:
     if options.no_build == False:
         print("Removing build directory: " + exeroot)
-        runcmd("rm -rf " + exeroot)
+        runcmd("rm -rf " + exeroot, check=False)
     print("Removing run directory: " + rundir)
-    runcmd("rm -rf " + rundir)
+    runcmd("rm -rf " + rundir, check=False)
 
 # ------Make domain, surface data and pftdyn files ------------------
 mysimyr = 1850
@@ -1390,10 +1395,7 @@ if options.nopointdata == False:
         ptcmd = ptcmd + " --humhol"
 
     print(ptcmd)
-    result = os.system(ptcmd)
-    if (result > 0):
-        print ('PointCLM:  Error creating point data.  Aborting')
-        sys.exit(1)
+    runcmd(ptcmd)
 
     if options.makepointdata_only:
         print(
@@ -1492,8 +1494,8 @@ if options.mod_parm_file != "":
 else:
     print(parm_file)
     print('nccopy -3 '+options.ccsm_input+'/lnd/clm2/paramdata/'+parm_file+' '+tmpdir+'/clm_params.nc')
-    os.system('nccopy -3 '+options.ccsm_input+'/lnd/clm2/paramdata/'+parm_file+' ' \
-              +tmpdir+'/clm_params.nc')
+    runcmd('nccopy -3 '+options.ccsm_input+'/lnd/clm2/paramdata/'+parm_file+' '
+           +tmpdir+'/clm_params.nc')
 
 myncap = 'ncap'
 if ( 'chrysalis' in options.machine or 'compy' in options.machine or 'ubuntu' in options.machine \
@@ -1507,23 +1509,23 @@ if ( 'chrysalis' in options.machine or 'compy' in options.machine or 'ubuntu' in
     #   print('humhol_dist = 1.0m')
       print('setting rsub_top_globalmax = 1.2e-5')
     #   print('Making br_mr a PFT-specific parameter')
-      os.system(myncap+' -O -s "humhol_ht = br_mr*0+0.15" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
+      runcmd(myncap+' -O -s "humhol_ht = br_mr*0+0.15" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
       if options.marsh:
-        os.system(myncap+' -O -s "hum_frac = br_mr*0+0.50" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
+        runcmd(myncap+' -O -s "hum_frac = br_mr*0+0.50" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
         print('hum_frac  = 0.50')
       else:
-        os.system(myncap+' -O -s "hum_frac = br_mr*0+0.64" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
+        runcmd(myncap+' -O -s "hum_frac = br_mr*0+0.64" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
         print('hum_frac  = 0.64')
-      os.system(myncap+' -O -s "humhol_dist = br_mr*0+1.0" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
+      runcmd(myncap+' -O -s "humhol_dist = br_mr*0+1.0" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
       if options.marsh:
         print('qflx_h2osfc_surfrate = 0.0')
-        os.system(myncap+' -O -s "qflx_h2osfc_surfrate = br_mr*0+0.0" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
+        runcmd(myncap+' -O -s "qflx_h2osfc_surfrate = br_mr*0+0.0" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
       else:
         print('qflx_h2osfc_surfrate = 1.0e-7')
-        os.system(myncap+' -O -s "qflx_h2osfc_surfrate = br_mr*0+1.0e-7" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
-      os.system(myncap+' -O -s "moss_swc_adjust=0" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
-      os.system(myncap+' -O -s "rsub_top_globalmax = br_mr*0+1.2e-5" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
-      os.system(myncap+' -O -s "h2osoi_offset = br_mr*0" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
+        runcmd(myncap+' -O -s "qflx_h2osfc_surfrate = br_mr*0+1.0e-7" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
+      runcmd(myncap+' -O -s "moss_swc_adjust=0" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
+      runcmd(myncap+' -O -s "rsub_top_globalmax = br_mr*0+1.2e-5" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
+      runcmd(myncap+' -O -s "h2osoi_offset = br_mr*0" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
     #   flnr = nffun.getvar(tmpdir+'/clm_params.nc','flnr')
     #   os.system(myncap+' -O -s "br_mr = flnr" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
     #   ierr = nffun.putvar(tmpdir+'/clm_params.nc','br_mr', flnr*0.0+2.52e-6)
@@ -1535,10 +1537,10 @@ if ( 'chrysalis' in options.machine or 'compy' in options.machine or 'ubuntu' in
 
         tidecomps = pandas.read_csv(options.tide_components_file)
         for comp in range(len(tidecomps)):
-            os.system(myncap+' -O -s "tide_coeff_amp_%d = humhol_ht*0+%1.4e" '%(comp+1,tidecomps['Amplitude'].iloc[comp]*1000)+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
-            os.system(myncap+' -O -s "tide_coeff_period_%d = humhol_ht*0+%1.4e" '%(comp+1,360*3600/tidecomps['Speed'].iloc[comp])+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
-            os.system(myncap+' -O -s "tide_coeff_phase_%d = humhol_ht*0+%1.4e" '%(comp+1,tidecomps['Phase'].iloc[comp]*math.pi/180)+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
-            os.system(myncap+' -O -s "tide_baseline = humhol_ht*0+800.0" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
+            runcmd(myncap+' -O -s "tide_coeff_amp_%d = humhol_ht*0+%1.4e" '%(comp+1,tidecomps['Amplitude'].iloc[comp]*1000)+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
+            runcmd(myncap+' -O -s "tide_coeff_period_%d = humhol_ht*0+%1.4e" '%(comp+1,360*3600/tidecomps['Speed'].iloc[comp])+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
+            runcmd(myncap+' -O -s "tide_coeff_phase_%d = humhol_ht*0+%1.4e" '%(comp+1,tidecomps['Phase'].iloc[comp]*math.pi/180)+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
+            runcmd(myncap+' -O -s "tide_baseline = humhol_ht*0+800.0" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
     elif options.marsh and options.tide_forcing_file == '':
         print('Tidal cycle coefficients not specified. Model will use GCREW defaults. Can also edit in parm file.')
     #os.system(myncap+' -O -s "crit_gdd1 = flnr" '+tmpdir+'/clm_params.nc '+tmpdir+'/clm_params.nc')
@@ -2832,13 +2834,10 @@ for i in range(1, int(options.ninst) + 1):
 
 #configure case
 #if (isglobal):
-os.system("./xmlchange BATCH_SYSTEM=none")
+runcmd("./xmlchange BATCH_SYSTEM=none")
 if (options.no_config == False):
     print('Running case.setup')
-    result = os.system('./case.setup > case_setup.log')
-    if (result > 0):
-        print('Error: runcase.py failed to setup case')
-        sys.exit(1)
+    runcmd('./case.setup > case_setup.log')
 else:
     print("Warning:  No case configure performed")
     sys.exit(1)
@@ -2867,9 +2866,7 @@ if (options.alquimia != ""):
     print("Turning on alquimia interface for compilation and running")
     # os.system("./xmlchange -id "+mylsm+"_CONFIG_OPTS --append --val '-cppdefs -DUSE_ALQUIMIA_LIB'")
     cppdefs.append('-DUSE_ALQUIMIA_LIB')
-    result = os.system("./xmlchange "+mylsm+"_USE_ALQUIMIA=TRUE")
-    if result != 0:
-        raise RuntimeError('Command failed: "./xmlchange '+mylsm+'_USE_ALQUIMIA=TRUE"')
+    runcmd("./xmlchange "+mylsm+"_USE_ALQUIMIA=TRUE")
 if (options.harvmod):
     print('Turning on HARVMOD modification\n')
     # os.system("./xmlchange -id "+mylsm+"_CONFIG_OPTS --append --val '-cppdefs -DHARVMOD'")
@@ -2882,7 +2879,7 @@ if len(cppdefs)>0:
             cppdefs_str = cppdefs_str + ' ' + cppdef
     cppdefs_str = cppdefs_str + '"'
     print("./xmlchange --append "+mylsm+"_CONFIG_OPTS='%s'"%(cppdefs_str))
-    os.system("./xmlchange --append "+mylsm+"_CONFIG_OPTS='%s'"%(cppdefs_str))
+    runcmd("./xmlchange --append "+mylsm+"_CONFIG_OPTS='%s'"%(cppdefs_str))
 
 # Global CPPDEF modifications
 if cpl_bypass:
@@ -2942,19 +2939,14 @@ if options.caseroot == "./":
 else:
     chdir(casedir)
 
-os.system('mkdir Srcfiles')
+runcmd('mkdir -p Srcfiles', check=False)
 #clean build if requested
 if (options.clean_build):
-    os.system('./case.build --clean')
+    runcmd('./case.build --clean', check=False)
 #compile model
 if (options.no_build == False):
     print('Running case.build')
-    result = os.system('./case.build') 
-    #result = os.system('./case.build > case_build.log')
-    if (result > 0):
-        print('Error:  Pointclm.py failed to build case.  Aborting')
-        print('See '+os.getcwd()+'/case_build.log for details')
-        sys.exit(1)
+    runcmd('./case.build')
 else:
     runcmd("./xmlchange BUILD_COMPLETE=TRUE")
     runcmd("mkdir -p " + rundir)
@@ -3123,9 +3115,9 @@ if not cpl_bypass and not isglobal:
         myoutput.close()
     # run preview_namelists to copy user_datm.streams.... to CaseDocs
     if os.path.exists(os.path.abspath(options.csmdir)+'/cime/scripts/Tools/preview_namelists'):
-      os.system(os.path.abspath(options.csmdir)+'/cime/scripts/Tools/preview_namelists')
+      runcmd(os.path.abspath(options.csmdir)+'/cime/scripts/Tools/preview_namelists')
     else:
-      os.system(os.path.abspath(options.csmdir)+'/cime/CIME/Tools/preview_namelists')
+      runcmd(os.path.abspath(options.csmdir)+'/cime/CIME/Tools/preview_namelists')
 
 
 # copy site data to run directory
@@ -3240,7 +3232,7 @@ if (options.ensemble_file != "" or int(options.mc_ensemble) != -1) and (
         options.machine == 'anvil' or options.machine == 'chrysalis'):
         mysubmit_type = 'sbatch'
     if (options.ensemble_file != ''):
-        os.system('mkdir -p '+PTCLMdir+'/scripts/'+myscriptsdir)
+        runcmd('mkdir -p '+PTCLMdir+'/scripts/'+myscriptsdir)
         output_run  = open(PTCLMdir+'/scripts/'+myscriptsdir+'/ensemble_run_'+casename+'.pbs','w')
         timestr=str(int(float(options.walltime)))+':'+str(int((float(options.walltime)- \
                                      int(float(options.walltime)))*60))+':00'

--- a/runcase.py
+++ b/runcase.py
@@ -1091,7 +1091,9 @@ else:
 # check for a specific forcing data, GSWP3-Daymet4, to offline ELM
 # This is high-resolution dataset, usually together with user-defined domain and surface data
 if options.daymet4:
-    if not options.gswp3:
+    if options.era5:
+        pass
+    elif not options.gswp3:
         options.gswp3 = True
     if options.metdir == "none":
         print('Error:  must provide user-defined " --metdir " for " --daymet4"')
@@ -1106,6 +1108,14 @@ if options.daymet4:
         if options.pftdynfile == "" and not options.nopftdyn:
             print('Error:  must provide user-defined " --pftdynfile " for " --daymet4"')
             sys.exit(1)
+    # RPF - add check to make sure daymet cannot be enabled with gswp3 AND era5
+    forcing_count = sum([options.gswp3, options.era5])
+    if forcing_count > 1:
+        print('Error: --daymet4 can only be combined with one base forcing (--gswp3 OR --era5, not both)')
+        sys.exit(1)
+    elif forcing_count == 0:
+        # Default to gswp3 if no forcing specified
+        options.gswp3 = True
 # ----------------------------------------------------------------------------------
 
 compset = options.compset

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -956,14 +956,16 @@ for row in AFdatareader:
             basecmd = basecmd + " --gswp3_w5e5"
         if options.princeton:
             basecmd = basecmd + " --princeton"
+        if options.era5:
+            basecmd = basecmd + " --era5"
         if options.daymet:
             basecmd = basecmd + " --daymet"
         if options.daymet4:  # gswp3 v2 spatially-downscaled by daymet v4, usually together with user-defined domain and surface data
             basecmd = basecmd + " --daymet4"
-            if not options.gswp3:
+            if options.era5:
+                pass
+            elif not options.gswp3:
                 basecmd = basecmd + " --gswp3"
-        if options.era5:
-            basecmd = basecmd + " --era5"
         if options.fates_paramfile != "":
             basecmd = basecmd + " --fates_paramfile " + options.fates_paramfile
         if options.fates_nutrient != "":

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -582,7 +582,7 @@ def _parse_cmd(cmd_i):
     return result
 
 
-def runcmd(cmd, echo=True, tag=os.path.basename(__file__)):
+def runcmd(cmd, echo=True, check=True, tag=os.path.basename(__file__)):
     lineno = inspect.stack()[1].lineno
     cmd_log = cmd
     if ".py" in cmd_log:
@@ -591,7 +591,12 @@ def runcmd(cmd, echo=True, tag=os.path.basename(__file__)):
 
     if echo:
         print(cmd)
-    return os.system(cmd)
+    result = os.system(cmd)
+    if check and result != 0:
+        print("Error: command failed with exit status "
+              + str(result) + ": " + cmd)
+        sys.exit(1)
+    return result
 
 
 # ----------------------------------------------------------
@@ -617,7 +622,7 @@ def submit(fname, submit_type="qsub", job_depend=""):
         myinput.close()
     else:
         thisjob = "0"
-        runcmd("rm temp/jobinfo")
+        runcmd("rm temp/jobinfo", check=False)
     return thisjob
 
 

--- a/srcmods_era5cb/src.elm/lnd_import_export.F90
+++ b/srcmods_era5cb/src.elm/lnd_import_export.F90
@@ -332,7 +332,7 @@ contains
             atm2lnd_vars%endyear_met_trans  = 2025
             !get year information from file, if available
             ! note the starting/ending year in file name(s) are removed.
-            ierr = nf90_open(trim(metdata_bypass) // '/'ERA5_TBOT_z01.nc', nf90_nowrite, ncid)
+            ierr = nf90_open(trim(metdata_bypass) // '/ERA5_TBOT_z01.nc', nf90_nowrite, ncid)
             ierr = nf90_inq_varid(ncid, 'start_year', varid)
             if (ierr == 0) then
               ierr = nf90_get_var(ncid, varid, atm2lnd_vars%startyear_met)


### PR DESCRIPTION
Augments @jsta's `runcmd` to return error code when command doesn't complete successfully. 

This PR also adds build and run logs as artifacts when the relevant stage fails on failing CI. Retention period of 1 day. 

Addresses the issue in #6, but doesn't fully fix it as `runcmd` still wraps `os.system()`. However, now we could just change `os.system` in one place and close that issue if we find deficiencies with `runcmd`