### PR TITLE
Isolate per-invocation staging files to fix concurrent-run race

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+OLMT (Offline Land Model Testbed) is a collection of Python scripts that automate ELM and CLM/CTSM simulations on top of E3SM/CIME. It is **not** a Python package — every script is a standalone top-level executable invoked via `python ./script.py …`. There is no `setup.py`, no module hierarchy, and scripts import each other by name from the repo root (e.g. `import netcdf4_functions as nffun`). Run them from the repo root.
+
+OLMT does not run the model itself; it generates and submits CIME cases. A working clone of an E3SM (or CESM/CTSM) source tree must exist separately and be passed via `--model_root`, along with an inputdata tree via `--ccsm_input`.
+
+## Common commands
+
+Lint (matches CI in `.github/workflows/ruff.yml`):
+```
+ruff check .
+```
+Config lives in `ruff.toml` (only `E712` is ignored).
+
+Install runtime deps:
+```
+pip install -r requirements.txt
+```
+`mpi4py` is only needed when running `manage_ensemble.py`; the single-site path does not require MPI.
+
+There is **no `pytest` test suite**. The integration test is the docker-based site-fullrun matrix in `.github/workflows/site-full-run.ci.yml`, which runs `site_fullrun.py` end-to-end against `NGEE-Arctic/E3SM@develop` inside `rfiorella/model-containers:e3sm-openmpi-dev-latest` for three forcing configurations (gswp3, era5, era5-daymet4). To reproduce a CI failure locally, run the same docker invocation that the workflow builds in its `Run … test for site` step.
+
+## High-level architecture
+
+### The three-phase BGC simulation pattern
+
+OLMT's central abstraction is the standard ELM BGC three-case sequence (see `README.md`):
+
+1. **ad_spinup** — accelerated decomposition spinup
+2. **final spinup** — equilibrate biomass/nutrient pools
+3. **transient** — 1850–present with prescribed forcing/land use/CO2
+
+`site_fullrun.py` and `global_fullrun.py` orchestrate this sequence. Flags `--noad`, `--nofnsp`, `--notrans` skip individual phases. `--eco2_file` adds parallel aCO2/eCO2 transient cases.
+
+### Script layering (which script calls which)
+
+```
+site_fullrun.py / global_fullrun.py    ← user entry point
+   │
+   ├── makepointdata.py                ← builds domain/surface/landuse NetCDF subsets
+   ├── runcase.py                      ← does create_newcase + xmlchange + namelist + build + (optional) submit for ONE case
+   └── case_copy.py                    ← clones an already-built case for additional sites (avoids rebuilding)
+```
+
+`site_fullrun.py` builds the **first** site by shelling out to `runcase.py` for each of the three phases. For every additional site (`--site` accepting a comma-list, or `all`), it calls `case_copy.py` to clone the first site's run directory and patch it, which is significantly faster than re-running `runcase.py`. The `firstsite` / `*_case_firstsite` variables in `site_fullrun.py` track this.
+
+`runcase.py` is the largest script (~3300 lines) and is where CIME interaction lives: building the `create_newcase` command, writing `user_nl_*` namelists, applying `--srcmods_loc` source modifications, and (for ensemble runs) generating PBS submission scripts. Its top-level docstring (around line 87) lists the seven steps it performs.
+
+Every shell-out goes through `runcase.runcmd()`, which logs commands to JSON (`--options_log_json`) and post-processes stderr to detect a CIME quirk where `case.submit` swallows exceptions as warnings (search for `"Exception from "`).
+
+### Ensembles and UQ
+
+Ensemble work uses a separate set of scripts driven by MPI:
+
+- `manage_ensemble.py` — MPI master that distributes parameter samples (`--ens_file`) across ranks, drives per-member runs via `ensemble_run.py`, and post-processes against `--postproc_file`.
+- `ensemble_run.py` / `ensemble_copy.py` — single ensemble member execution; require a pre-built parent case (single-point, MPI-serial only).
+- `MCMC.py`, `model_surrogate.py`, `surrogate_NN.py`, `run_GSA.py` — surrogate modeling and sensitivity workflows. `UQTk_scripts/` holds shell drivers for UQTk-based sensitivity.
+
+Parameter perturbation files use the `parm_list` format: one line per parameter, four whitespace-separated fields `name pft min max`. Examples in `examples/parm_list*`. Post-processing variable specs use the `postproc_vars` format documented in the header of `examples/postproc_vars_example`.
+
+### Site metadata
+
+`inputdata/PTCLM/<sitegroup>_sitedata.txt` is the lookup table that maps site codes (`--site`) to lat/lon/PFT/year ranges. `--sitegroup` picks the file (default `AmeriFlux`; `NGEEArctic` is used by CI). Adding a new site means appending a row here (and to the matching `_pftdata.txt` / `_soildata.txt`).
+
+### Met forcing flags
+
+The forcing-source flags in `site_fullrun.py` (`--cruncep`, `--cruncepv8`, `--era5`, `--gswp3`, `--gswp3_w5e5`, `--princeton`, `--crujra`, `--trendy25`) are mutually-exclusive selectors that do two things: they hard-code the spinup met cycle to 1901–1920 and they pick a per-source `endyear_trans` (the latest year of available forcing). When adding a new forcing source, both branches in `site_fullrun.py` (around line 814) need updating, and `runcase.py` needs the matching cpl_bypass / DATM logic.
+
+### Source modifications
+
+`srcmods_era5cb/src.elm/` ships an `lnd_import_export.F90` override needed for the ERA5 + cpl_bypass path. The CI workflow only passes `--srcmods_loc` for the ERA5 cases — this is intentional. Other src mods are expected to live outside the repo.
+
+## Conventions worth knowing
+
+- **Argument parsing uses `optparse`**, not `argparse`. `optparse` is deprecated in stdlib but is consistent across all scripts; do not "modernise" one script in isolation.
+- **NetCDF I/O has two helpers**: `netcdf_functions.py` (legacy, scipy/Scientific fallback) and `netcdf4_functions.py` (preferred, used by newer scripts as `nffun`). Use `netcdf4_functions` for new code.
+- **`run.*`, `scripts/`, `temp/`, `plots/`, `mcsamples*.txt`** are runtime outputs and gitignored — don't commit them.
+- **`./temp/` is per-invocation, not shared.** `site_fullrun.py`, `global_fullrun.py`, `runcase.py`, `makepointdata.py`, and `case_copy.py` each accept `--tempdir <path>`; when omitted they default to `./temp/run_<pid>_<ms>/`. Top-level fullrun scripts compute one tempdir at startup and forward it to every child shell-out. This isolates concurrent OLMT invocations from each other (previously they shared `./temp/clm_params.nc` etc. and would corrupt each other's staging). When debugging, look one directory deeper than the legacy `./temp/`.
+- **Commit message style** (from `git log`): short imperative subject, no Conventional Commits prefix. Match the existing tone.
+- **CI base branch is `develop`**, not `main`. PRs target `develop`.

--- a/case_copy.py
+++ b/case_copy.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import time
 from optparse import OptionParser
 
 #Create, run and process a CLM/ELM model ensemble member
@@ -45,7 +46,15 @@ parser.add_option('--machine', dest='machine', default='cades', \
                   help = 'machine')
 parser.add_option('--warming', dest='warming', default='0.0', \
                   help = 'warming level to apply')
+parser.add_option('--tempdir', dest='tempdir', default='', \
+                  help = 'Per-invocation staging directory; defaults to ./temp/run_<pid>_<ms>')
 (options, args) = parser.parse_args()
+
+if options.tempdir:
+    tempdir = os.path.abspath(options.tempdir)
+else:
+    tempdir = os.path.abspath('./temp/run_%d_%d' % (os.getpid(), int(time.time() * 1000)))
+os.makedirs(tempdir, exist_ok=True)
 
 
 casename = options.casename
@@ -133,22 +142,22 @@ for f in os.listdir(new_dir):
 if (options.site_orig == options.site_new and os.path.exists(orig_dir+'/surfdata.nc')):
   os.system('cp '+orig_dir+'/surfdata.nc '+new_dir)
 else:
-  os.system('cp temp/surfdata.nc '+new_dir)
+  os.system('cp '+tempdir+'/surfdata.nc '+new_dir)
 if (options.site_orig == options.site_new and os.path.exists(orig_dir+'/domain.nc')):
   os.system('cp '+orig_dir+'/domain.nc '+new_dir)
 else:
-  os.system('cp temp/domain.nc '+new_dir)
+  os.system('cp '+tempdir+'/domain.nc '+new_dir)
 
 
 os.system('pwd')
 if ('20TR' in options.casename and not options.nolanduse):
-   os.system('cp temp/*pftdyn*.nc '+new_dir)
+   os.system('cp '+tempdir+'/*pftdyn*.nc '+new_dir)
 
 
 #if a global file exists, modify
-if (os.path.exists('temp/global_'+options.casename+'_0.pbs') and options.suffix != ''):
-  file_in = open('temp/global_'+options.casename+'_0.pbs','r')
-  file_out =open('temp/global_'+options.casename+'_'+options.suffix+'.pbs','w')
+if (os.path.exists(tempdir+'/global_'+options.casename+'_0.pbs') and options.suffix != ''):
+  file_in = open(tempdir+'/global_'+options.casename+'_0.pbs','r')
+  file_out =open(tempdir+'/global_'+options.casename+'_'+options.suffix+'.pbs','w')
   mpicmd = 'mpirun -np '+str(np)
   if ('cades' in options.machine):
     mpicmd = '/software/dev_tools/swtree/cs400_centos7.2_pe2016-08/openmpi/1.10.3/centos7.2_gnu5.3.0/bin/mpirun'+ \
@@ -168,9 +177,9 @@ if (os.path.exists('temp/global_'+options.casename+'_0.pbs') and options.suffix 
   file_out.close()
   print("Submitting the job:")
   if ('cades' in options.machine or 'cori' in options.machine or 'edison' in options.machine):
-    os.system('sbatch temp/global_'+options.casename+'_'+options.suffix+'.pbs')
+    os.system('sbatch '+tempdir+'/global_'+options.casename+'_'+options.suffix+'.pbs')
   else:
-    os.system('qsub temp/global_'+options.casename+'_'+options.suffix+'.pbs')
+    os.system('qsub '+tempdir+'/global_'+options.casename+'_'+options.suffix+'.pbs')
 
 #if an ensemble script exists, make a copy for this site
 if (options.site_orig != ''):

--- a/global_fullrun.py
+++ b/global_fullrun.py
@@ -4,6 +4,7 @@ import getpass
 import os
 import sys
 import math
+import time
 from optparse import OptionParser
 import numpy
 import re
@@ -89,6 +90,8 @@ parser.add_option('--runblock', dest="runblock", default=9999, \
                   help="Number of years to run for each submission")
 parser.add_option("--runroot", dest="runroot", default="", \
                   help="Directory where the run would be created")
+parser.add_option("--tempdir", dest="tempdir", default="", \
+                  help="Per-invocation staging directory; defaults to ./temp/run_<pid>_<ms>")
 parser.add_option("--run_startyear", dest="run_startyear",default=-1, \
                       help='Starting year for model output (SP only)')
 parser.add_option("--srcmods_loc", dest="srcmods_loc", default='', \
@@ -197,22 +200,30 @@ parser.add_option("--use_extra_snow_layers", dest = "use_extra_snow_layers", def
 
 (options, args) = parser.parse_args()
 
+# Resolve per-invocation tempdir up front; defaults to ./temp/run_<pid>_<ms>.
+if options.tempdir:
+    tempdir = os.path.abspath(options.tempdir)
+else:
+    tempdir = os.path.abspath('./temp/run_%d_%d' % (os.getpid(), int(time.time() * 1000)))
+os.makedirs(tempdir, exist_ok=True)
+
 #------------ define function for pbs submission
 def submit(fname, submit_type='qsub', job_depend=''):
+    jobinfo = tempdir + '/jobinfo'
     if (job_depend != ''):
         if (submit_type == 'qsub'):
-            os.system(submit_type+' -W depend=afterok:'+job_depend+' '+fname+' > temp/jobinfo')
+            os.system(submit_type+' -W depend=afterok:'+job_depend+' '+fname+' > '+jobinfo)
         elif (submit_type == 'sbatch'):
-            os.system(submit_type+' -d afterok:'+job_depend+' '+fname+' > temp/jobinfo')
+            os.system(submit_type+' -d afterok:'+job_depend+' '+fname+' > '+jobinfo)
     else:
-        os.system(submit_type+' '+fname+' > temp/jobinfo')
-    myinput = open('temp/jobinfo')
+        os.system(submit_type+' '+fname+' > '+jobinfo)
+    myinput = open(jobinfo)
     thisjob=''
     if (submit_type != ''):
       for s in myinput:
           thisjob = re.search('[0-9]+', s).group(0)
     myinput.close()
-    os.system('rm temp/jobinfo')
+    os.system('rm '+jobinfo)
     return thisjob
 
 def get_regional_bounds(myregion):
@@ -588,6 +599,7 @@ if (options.mpilib != ''):
     basecmd = basecmd + ' --mpilib '+options.mpilib
 basecmd = basecmd+' --caseroot '+caseroot
 basecmd = basecmd+' --runroot '+runroot
+basecmd = basecmd+' --tempdir '+tempdir
 basecmd = basecmd+' --walltime '+str(options.walltime)
 basecmd = basecmd+' --lat_bounds '+str(lat_bounds[0])+','+str(lat_bounds[1])
 basecmd = basecmd+' --lon_bounds '+str(lon_bounds[0])+','+str(lon_bounds[1])
@@ -808,7 +820,7 @@ if (options.mc_ensemble <= 0):
     #Create a .PBS site fullrun script to launch the full job 
 
     for n in range(0,n_submits):
-        output = open('./temp/global_'+c+'_'+str(n)+'.pbs','w')
+        output = open(tempdir+'/global_'+c+'_'+str(n)+'.pbs','w')
         if (os.path.isfile(caseroot+'/'+c+'/case.run')):
             input = open(caseroot+'/'+c+'/case.run')
         elif (os.path.isfile(caseroot+'/'+c+'/.case.run')):
@@ -929,7 +941,7 @@ if (options.mc_ensemble <= 0):
         output.close()
 
         if not options.no_submit:
-            os.system('chmod u+x temp/global_'+c+'_'+str(n)+'.pbs') 
-            job_depend_run = submit('temp/global_'+c+'_'+str(n)+'.pbs',job_depend=job_depend_run, \
+            os.system('chmod u+x '+tempdir+'/global_'+c+'_'+str(n)+'.pbs')
+            job_depend_run = submit(tempdir+'/global_'+c+'_'+str(n)+'.pbs',job_depend=job_depend_run, \
                                     submit_type=mysubmit_type)
         

--- a/makepointdata.py
+++ b/makepointdata.py
@@ -3,6 +3,7 @@ import os
 import sys
 import csv
 import math
+import time
 from optparse import OptionParser
 import numpy
 import netcdf4_functions as nffun
@@ -61,15 +62,23 @@ parser.add_option("--usersurfnc", dest="usersurfnc", default="none", \
                   help = 'User-provided surface data nc file, with one or more variable(s) as defined')
 parser.add_option("--usersurfvar", dest="usersurfvar", default="none", \
                   help = 'variable name(s) in User-provided surface data nc file, separated by ","')
+parser.add_option("--tempdir", dest="tempdir", default="", \
+                  help = 'Per-invocation staging directory; defaults to ./temp/run_<pid>_<ms>')
 (options, args) = parser.parse_args()
 
 
 ccsm_input = os.path.abspath(options.ccsm_input)
 
+if options.tempdir:
+    tempdir = os.path.abspath(options.tempdir)
+else:
+    tempdir = os.path.abspath('./temp/run_%d_%d' % (os.getpid(), int(time.time() * 1000)))
+os.makedirs(tempdir, exist_ok=True)
+
 #------------------- get site information ----------------------------------
 
-#Remove existing temp files
-os.system('find ./temp/ -name "*.nc*" -exec rm {} \; ')
+#Remove existing temp files in this invocation's tempdir
+os.system('find ' + tempdir + ' -name "*.nc*" -exec rm {} \; ')
 
 lat_bounds = options.lat_bounds.split(',')
 lon_bounds = options.lon_bounds.split(',')
@@ -365,7 +374,7 @@ os.environ["PATH"] += ':/Users/f9y/ATS_ROOT/amanzi_tpls-install-master-Debug/bin
 domainfile_tmp = 'domain??????.nc' # filename pattern of 'domainfile_new'
 for n in range(0,n_grids):
     nst = str(1000000+n)[1:]
-    domainfile_new = './temp/domain'+nst+'.nc'
+    domainfile_new = tempdir+'/domain'+nst+'.nc'
     if (not os.path.exists(domainfile_orig)):
         print('Error:  '+domainfile_orig+' does not exist.  Aborting')
         sys.exit(1)
@@ -461,10 +470,10 @@ for n in range(0,n_grids):
 
     domainfile_old = domainfile_new
 
-domainfile_new = './temp/domain.nc'
+domainfile_new = tempdir+'/domain.nc'
 if (n_grids > 1):
     #ierr = os.system('ncrcat -h '+domainfile_list+' '+domainfile_new) # OS error if '_list' too long
-    ierr = os.system('find ./temp/ -name "'+domainfile_tmp+ \
+    ierr = os.system('find '+tempdir+' -name "'+domainfile_tmp+ \
                      '" | xargs ls | sort | ncrcat -O -h -o'+domainfile_new)
     if(ierr!=0): 
         raise RuntimeError('Error: ncrcat -', ierr) #os.sys.exit()
@@ -483,7 +492,7 @@ if (n_grids > 1):
     ierr = os.system('ncrename -h -O -d ni_temp,nj '+domainfile_new+' '+domainfile_new+' ')
     if(ierr!=0): 
         raise RuntimeError('Error: ncrename', ierr) #os.sys.exit()
-    os.system('find ./temp/ -name '+domainfile_tmp+' -exec rm {} \;')
+    os.system('find '+tempdir+' -name '+domainfile_tmp+' -exec rm {} \;')
     os.system('rm '+domainfile_new+'.tmp*')
 else:
     ierr = os.system('mv '+domainfile_old+' '+domainfile_new)
@@ -511,7 +520,7 @@ print('Creating surface data')
 surffile_tmp = 'surfdata??????.nc' # filename pattern of 'surffile_new'
 for n in range(0,n_grids):
     nst = str(1000000+n)[1:]
-    surffile_new =  './temp/surfdata'+nst+'.nc'
+    surffile_new =  tempdir+'/surfdata'+nst+'.nc'
     if (not os.path.exists(surffile_orig)):
         print('Error:  '+surffile_orig+' does not exist.  Aborting')
         sys.exit(1)
@@ -765,16 +774,16 @@ for n in range(0,n_grids):
 
     surffile_old = surffile_new
 
-surffile_new = './temp/surfdata.nc'
+surffile_new = tempdir+'/surfdata.nc'
 
 if (n_grids > 1):
   #os.system('ncecat '+surffile_list+' '+surffile_new) # not works with too long '_list'
-  ierr = os.system('find ./temp/ -name "'+surffile_tmp+ \
+  ierr = os.system('find '+tempdir+' -name "'+surffile_tmp+ \
                  '" | xargs ls | sort | ncecat -O -h -o'+surffile_new)
-  if(ierr!=0): 
+  if(ierr!=0):
       raise RuntimeError('Error: ncecat ') #os.sys.exit()
-  #os.system('rm ./temp/surfdata?????.nc*') # not works with too many files
-  os.system('find ./temp/ -name "'+surffile_tmp+'" -exec rm {} \;')
+  #os.system('rm <tempdir>/surfdata?????.nc*') # not works with too many files
+  os.system('find '+tempdir+' -name "'+surffile_tmp+'" -exec rm {} \;')
 
   #remove ni dimension
   ierr = os.system('ncwa -h -O -a lsmlat -d lsmlat,0,0 '+surffile_new+' '+surffile_new+'.tmp')
@@ -816,7 +825,7 @@ if (not options.nopftdyn):
   pftdyn_tmp = 'surfdata.pftdyn??????.nc' # filename pattern of 'pftdyn_new'
   for n in range(0,n_grids):
     nst = str(1000000+n)[1:]
-    pftdyn_new = './temp/surfdata.pftdyn'+nst+'.nc'
+    pftdyn_new = tempdir+'/surfdata.pftdyn'+nst+'.nc'
     
     if (not os.path.exists(pftdyn_orig)):
         print('Error: '+pftdyn_orig+' does not exist.  Aborting')
@@ -1004,20 +1013,20 @@ if (not options.nopftdyn):
         ierr = nffun.putvar(pftdyn_new, 'HARVEST_VH2', harvest_vh2)
     pftdyn_old = pftdyn_new
 
-  pftdyn_new = './temp/surfdata.pftdyn.nc'
+  pftdyn_new = tempdir+'/surfdata.pftdyn.nc'
   if (os.path.isfile(pftdyn_new)):
       print('Warning:  Removing existing pftdyn data file')
       os.system('rm -rf '+pftdyn_new)
 
   if (n_grids > 1):
       #ios.system('ncecat -h '+pftdyn_list+' '+pftdyn_new) # not works with too long '_list'
-      ierr = os.system('find ./temp/ -name "'+pftdyn_tmp+ \
+      ierr = os.system('find '+tempdir+' -name "'+pftdyn_tmp+ \
                     '" | xargs ls | sort | ncecat -O -h -o'+pftdyn_new)
-      if(ierr!=0): 
+      if(ierr!=0):
             raise RuntimeError('Error: ncecat ') #os.sys.exit()
 
-      #os.system('rm ./temp/surfdata.pftdyn?????.nc*') # 'rm' not works for too long file list
-      os.system('find ./temp/ -name "'+pftdyn_tmp+'" -exec rm {} \;')
+      #os.system('rm <tempdir>/surfdata.pftdyn?????.nc*') # 'rm' not works for too long file list
+      os.system('find '+tempdir+' -name "'+pftdyn_tmp+'" -exec rm {} \;')
 
       #remove ni dimension
       ierr = os.system('ncwa -h -O -a lsmlat -d lsmlat,0,0 '+pftdyn_new+' '+pftdyn_new+'.tmp')

--- a/runcase.py
+++ b/runcase.py
@@ -9,6 +9,7 @@ import json
 import numpy
 import inspect
 import subprocess
+import time
 from optparse import OptionParser
 
 
@@ -116,6 +117,12 @@ parser.add_option(
     dest="runroot",
     default="",
     help="Directory where the run would be created",
+)
+parser.add_option(
+    "--tempdir",
+    dest="tempdir",
+    default="",
+    help="Per-invocation staging directory; defaults to ./temp/run_<pid>_<ms>",
 )
 parser.add_option(
     "--model_root", dest="csmdir", default="", help="base model directory"
@@ -1063,6 +1070,16 @@ if (options.ensemble_file == ''):
 
 PTCLMdir = os.getcwd()
 
+# Resolve per-invocation tempdir up front so child shell-outs (e.g. makepointdata.py)
+# share it. Default to ./temp/run_<pid>_<ms> so concurrent invocations cannot collide.
+if options.tempdir:
+    tmpdir = os.path.abspath(options.tempdir)
+else:
+    tmpdir = os.path.abspath(
+        PTCLMdir + "/temp/run_%d_%d" % (os.getpid(), int(time.time() * 1000))
+    )
+os.makedirs(tmpdir, exist_ok=True)
+
 # if (options.hist_vars != ''):
 #    hist_vars = os.path.abspath(options.hist_vars)
 
@@ -1371,6 +1388,8 @@ if options.nopointdata == False:
         + str(mysimyr)
         + " --model "
         + options.mymodel
+        + " --tempdir "
+        + tmpdir
     )
     if options.metdir != "none":
         ptcmd = ptcmd + " --metdir " + options.metdir
@@ -1426,7 +1445,7 @@ if options.nopointdata == False:
             "PointCLM:  Successfully creating point data ONLY, i.e. no further config/build/run CLM/ELM"
         )
         print(
-            "PointCLM:  Files are in ./temp/*.nc, which you may save/rename properly for later use"
+            "PointCLM:  Files are in " + tmpdir + "/*.nc, which you may save/rename properly for later use"
         )
         sys.exit(0)
 
@@ -1496,9 +1515,7 @@ if isglobal == False:
     ptstr = str(numxpts) + "x" + str(numypts) + "pt"
 chdir(csmdir + "/cime/scripts")
 
-# parameter (pft-phys) modifications if desired
-tmpdir = PTCLMdir + "/temp"
-
+# parameter (pft-phys) modifications if desired (tmpdir already resolved at top of script)
 if options.mycaseid == "":
     myscriptsdir = "none"
 else:
@@ -1675,7 +1692,6 @@ if options.mymodel == "ELM":
             # assume in pointclm directory
             input = open(PTCLMdir + "/" + options.parm_file_P)
         else:  # assume full path given
-            input = open(os.path.abspath(options.parm_file_P))
             input = open(os.path.abspath(options.parm_file_P))
         for s in input:
             if s[0:1] != "#":
@@ -3142,16 +3158,16 @@ if not cpl_bypass and not isglobal:
 
 
 # copy site data to run directory
-runcmd("cp " + PTCLMdir + "/temp/*param*.nc " + runroot + "/" + casename + "/run/")
+runcmd("cp " + tmpdir + "/*param*.nc " + runroot + "/" + casename + "/run/")
 if options.domainfile == "":
-    runcmd("cp " + PTCLMdir + "/temp/domain.nc " + runroot + "/" + casename + "/run/")
+    runcmd("cp " + tmpdir + "/domain.nc " + runroot + "/" + casename + "/run/")
 if options.surffile == "":
-    runcmd("cp " + PTCLMdir + "/temp/surfdata.nc " + runroot + "/" + casename + "/run/")
+    runcmd("cp " + tmpdir + "/surfdata.nc " + runroot + "/" + casename + "/run/")
 if "20TR" in compset and options.nopftdyn == False and options.pftdynfile == "":
     runcmd(
         "cp "
-        + PTCLMdir
-        + "/temp/surfdata.pftdyn.nc "
+        + tmpdir
+        + "/surfdata.pftdyn.nc "
         + runroot
         + "/"
         + casename

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -5,6 +5,7 @@ import getpass
 import os
 import sys
 import csv
+import time
 from optparse import OptionParser
 import numpy
 import re
@@ -40,6 +41,12 @@ parser.add_option(
     dest="runroot",
     default="",
     help="Directory where the run would be created",
+)
+parser.add_option(
+    "--tempdir",
+    dest="tempdir",
+    default="",
+    help="Per-invocation staging directory; defaults to ./temp/run_<pid>_<ms>",
 )
 parser.add_option(
     "--exeroot", dest="exeroot", default="", help="Location of executable"
@@ -550,6 +557,16 @@ parser.add_option(
 (options, args) = parser.parse_args()
 
 
+# Resolve per-invocation tempdir up front so submit()/runcmd helpers and every child
+# shell-out share the same staging dir. Defaults to ./temp/run_<pid>_<ms> so two
+# concurrent site_fullrun.py invocations cannot collide on shared filenames.
+if options.tempdir:
+    tempdir = os.path.abspath(options.tempdir)
+else:
+    tempdir = os.path.abspath('./temp/run_%d_%d' % (os.getpid(), int(time.time() * 1000)))
+os.makedirs(tempdir, exist_ok=True)
+
+
 def _write_cmd(cmd, tag, lineno):
     if options.options_log_json == 'None':
         return
@@ -617,27 +634,28 @@ def runcmd(
 # ----------------------------------------------------------
 # define function for pbs submission
 def submit(fname, submit_type="qsub", job_depend=""):
+    jobinfo = tempdir + "/jobinfo"
     job_depend_flag = " -W depend=afterok:"
     if "sbatch" in submit_type:
         job_depend_flag = " --dependency=afterok:"
     if job_depend != "" and submit_type != "":
         runcmd(
-            submit_type + job_depend_flag + job_depend + " " + fname + " > temp/jobinfo"
+            submit_type + job_depend_flag + job_depend + " " + fname + " > " + jobinfo
         )
     else:
         if submit_type == "":
             runcmd("chmod a+x " + fname)
-            runcmd("./" + fname + " > temp/jobinfo")
+            runcmd("./" + fname + " > " + jobinfo)
         else:
-            runcmd(submit_type + " " + fname + " > temp/jobinfo")
+            runcmd(submit_type + " " + fname + " > " + jobinfo)
     if submit_type != "" and not options.dryrun:
-        myinput = open("temp/jobinfo")
+        myinput = open(jobinfo)
         for s in myinput:
             thisjob = re.search("[0-9]+", s).group(0)
         myinput.close()
     else:
         thisjob = "0"
-        runcmd("rm temp/jobinfo", check=False)
+        runcmd("rm " + jobinfo, check=False)
     return thisjob
 
 
@@ -894,6 +912,8 @@ for row in AFdatareader:
             + options.sitegroup
             + " --options_log_json "
             + options.options_log_json
+            + " --tempdir "
+            + tempdir
         )
         if options.machine != "":
             basecmd = basecmd + " --machine " + options.machine
@@ -1490,6 +1510,8 @@ for row in AFdatareader:
                 + ccsm_input
                 + " --model "
                 + mymodel
+                + " --tempdir "
+                + tempdir
             )
             if options.nopftdyn:
                 ptcmd = ptcmd + " --nopftdyn"
@@ -1524,6 +1546,8 @@ for row in AFdatareader:
                     + str(ny_ad)
                     + " --spin_cycle "
                     + str(endyear - startyear + 1)
+                    + " --tempdir "
+                    + tempdir
                 )
                 result = runcmd(ptcmd)
             if result > 0:
@@ -1553,6 +1577,8 @@ for row in AFdatareader:
                     + site
                     + " --nyears "
                     + str(ny_fin)
+                    + " --tempdir "
+                    + tempdir
                 )
                 if not options.sp:
                     ptcmd = (
@@ -1594,6 +1620,8 @@ for row in AFdatareader:
                     + str(int(ny_fin) + 1)
                     + " --nyears "
                     + str(translen)
+                    + " --tempdir "
+                    + tempdir
                 )
                 result = runcmd(ptcmd)
             if (


### PR DESCRIPTION
  site_fullrun.py, global_fullrun.py, runcase.py, makepointdata.py, and
  case_copy.py all staged files in a shared ./temp/ directory with fixed
  filenames (clm_params.nc, surfdata.nc, domain.nc, surfdata.pftdyn.nc,
  CNP_parameters.nc, jobinfo, global_*.pbs). Two concurrent site_fullrun.py
  invocations from the same OLMT clone could overwrite each other's
  staging files before they were copied into the case run directory, so
  the wrong inputs would land in the wrong run dir. makepointdata.py also
  wiped all *.nc* in ./temp/ on startup, which would destroy a sibling
  run's files outright.

  Add a --tempdir option to all five scripts. When unset, each script
  generates its own ./temp/run_<pid>_<ms>/ at startup. site_fullrun.py
  and global_fullrun.py compute the tempdir once and forward --tempdir
  on every child shell-out so all phases (ad_spinup, final_spinup,
  transient) and all sites in one invocation share the same isolated
  staging dir. The startup *.nc* wipe in makepointdata.py is now scoped
  to the per-invocation tempdir, so it can no longer touch sibling runs.

Fixes #12 