### PR TITLE
Add scripts for plotting input forcing against ELM output forcing fields

### DIFF
--- a/metdata_tools/calc_met_forcing_year.py
+++ b/metdata_tools/calc_met_forcing_year.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Annotate ELM output with per-timestep forcing years.
+
+This script mirrors the CPL_BYPASS year-indexing behavior in
+`lnd_import_export.F90` and writes a required field named `met_forcing_year`
+into an existing ELM output NetCDF file (in place).
+"""
+
+import argparse
+import re
+import sys
+from typing import Any, Dict, Optional, Tuple
+
+try:
+    import netCDF4 as nc
+except Exception:
+    nc = None
+
+
+def fortran_mod(a: int, p: int) -> int:
+    """Fortran MOD(a, p): a - INT(a/p) * p, where INT truncates toward zero."""
+    return a - int(a / p) * p
+
+
+def parse_lnd_in(lnd_in_path: str) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    with open(lnd_in_path, "r", encoding="utf-8") as f:
+        text = f.read()
+
+    match = re.search(r"metdata_type\s*=\s*'([^']+)'", text, flags=re.IGNORECASE)
+    if match:
+        result["metdata_type"] = match.group(1).strip()
+
+    match = re.search(r"metdata_bypass\s*=\s*'([^']+)'", text, flags=re.IGNORECASE)
+    if match:
+        result["metdata_bypass"] = match.group(1).strip()
+
+    return result
+
+
+def read_year_attrs(nc_path: str) -> Tuple[int, int]:
+    if nc is None:
+        raise RuntimeError("netCDF4 is not installed, cannot read start_year/end_year.")
+
+    ds = nc.Dataset(nc_path, "r")
+    try:
+        start_year = int(ds.variables["start_year"][:].squeeze())
+        end_year = int(ds.variables["end_year"][:].squeeze())
+    finally:
+        ds.close()
+
+    return start_year, end_year
+
+
+def metsource_from_metdata_type(metdata_type: str) -> int:
+    t = metdata_type.lower()
+    if "qian" in t:
+        return 0
+    if "cru" in t:
+        return 1
+    if "site" in t:
+        return 2
+    if "princeton" in t:
+        return 3
+    if "gswp3" in t:
+        return 4
+    if "cpl" in t:
+        return 5
+    if "era5" in t:
+        return 6
+    raise ValueError(f"Unsupported metdata_type: {metdata_type}")
+
+
+def infer_met_year_ranges(
+    metdata_type: str,
+    site_metadata_file: Optional[str] = None,
+    era5_metadata_file: Optional[str] = None,
+) -> Tuple[int, int, int, int]:
+    """
+    Infer met year control values following lnd_import_export.F90 logic.
+
+    Returns:
+      (metsource, startyear_met, endyear_met_spinup, endyear_met_trans)
+    """
+    t = metdata_type.lower()
+    metsource = metsource_from_metdata_type(metdata_type)
+
+    # Defaults used before source-specific overrides.
+    startyear_met = 1901
+    endyear_met_spinup = 1920
+    endyear_met_trans = 1920
+
+    if metsource == 0:  # qian
+        startyear_met = 1948
+        endyear_met_spinup = 1972
+        endyear_met_trans = 2004
+    elif metsource == 1:  # cru/cruncep/crujra variants
+        endyear_met_trans = 2016
+    elif metsource == 2:  # site
+        if not site_metadata_file:
+            raise ValueError(
+                "site met source requires --site-metadata-file (all_hourly.nc)."
+            )
+        startyear_met, endyear_met_spinup = read_year_attrs(site_metadata_file)
+        endyear_met_trans = endyear_met_spinup
+    elif metsource == 3:  # princeton
+        endyear_met_trans = 2012
+    elif metsource == 4:  # gswp3
+        endyear_met_trans = 2014
+    elif metsource == 5:  # cpl
+        startyear_met = 566
+        endyear_met_spinup = 590
+        endyear_met_trans = 590
+    elif metsource == 6:  # era5
+        startyear_met = 1950
+        endyear_met_spinup = 1970
+        endyear_met_trans = 2025
+        # Flexible ERA5 files can provide start/end years from metadata.
+        if era5_metadata_file:
+            startyear_met, endyear_met_trans = read_year_attrs(era5_metadata_file)
+            endyear_met_spinup = min(endyear_met_trans, 1970)
+
+    # livneh/daymet flags override start/spinup period in the Fortran logic.
+    use_livneh = "livneh" in t
+    use_daymet = "daymet" in t
+
+    if use_livneh:
+        startyear_met = 1950
+        endyear_met_spinup = 1969
+    elif use_daymet:
+        startyear_met = 1980
+        endyear_met_spinup = endyear_met_trans
+
+    return metsource, startyear_met, endyear_met_spinup, endyear_met_trans
+
+
+def forcing_year_for_sim_year(
+    sim_year: int,
+    metsource: int,
+    startyear_met: int,
+    endyear_met_spinup: int,
+    endyear_met_trans: int,
+) -> int:
+    """Map simulation year to forcing-file year using CPL_BYPASS rules.
+
+    Important: this returns the actual year represented by the forcing files
+    (for example 1901-1920), not the intermediate model-aligned year used to
+    compute index offsets in the Fortran code.
+    """
+    nyears_spinup = endyear_met_spinup - startyear_met + 1
+    if nyears_spinup <= 0:
+        raise ValueError("Invalid met range: spinup cycle length is non-positive.")
+
+    mystart = startyear_met
+    while mystart > 1850:
+        mystart -= nyears_spinup
+    if metsource == 5:
+        mystart = 1850
+
+    offset = 1850 - mystart
+
+    def _spin_cycle_year(expr: int) -> int:
+        # This mirrors tindex year-block logic in Fortran, then converts to an
+        # actual forcing-file year by wrapping back into [startyear_met, endyear_met_spinup].
+        year_block = fortran_mod(expr, nyears_spinup) + offset
+        forcing_idx = year_block % nyears_spinup
+        return startyear_met + forcing_idx
+
+    if sim_year < 1850:
+        return _spin_cycle_year(sim_year - 1)
+
+    if sim_year <= endyear_met_spinup:
+        return _spin_cycle_year(sim_year - 1850)
+
+    if sim_year <= endyear_met_trans:
+        return sim_year
+
+    # After transient period, wrap over the trailing spinup-length window.
+    last_window_start = endyear_met_trans - nyears_spinup + 1
+    return last_window_start + ((sim_year - (endyear_met_trans + 1)) % nyears_spinup)
+
+
+def phase_for_year(sim_year: int, endyear_met_spinup: int, endyear_met_trans: int) -> str:
+    if sim_year < 1850:
+        return "pre1850_spin_cycle"
+    if sim_year <= endyear_met_spinup:
+        return "spin_cycle"
+    if sim_year <= endyear_met_trans:
+        return "transient_direct"
+    return "post_transient_tail_cycle"
+
+
+def _detect_time_var_name(ds: Any) -> str:
+    if "time" in ds.variables:
+        return "time"
+    if "DTIME" in ds.variables:
+        return "DTIME"
+    for var_name, var in ds.variables.items():
+        if len(var.dimensions) == 1 and "time" in var_name.lower():
+            return var_name
+    raise ValueError("Could not detect a time coordinate variable in output file.")
+
+
+def _extract_simulation_years(ds: Any, time_var_name: str) -> list[int]:
+    time_var = ds.variables[time_var_name]
+    if not hasattr(time_var, "units"):
+        raise ValueError(
+            f"Time variable '{time_var_name}' is missing required 'units' attribute."
+        )
+
+    calendar = getattr(time_var, "calendar", "standard")
+    raw_time = time_var[:]
+
+    try:
+        decoded = nc.num2date(raw_time, units=time_var.units, calendar=calendar)
+    except Exception as exc:
+        raise ValueError(
+            f"Failed to decode time variable '{time_var_name}' using units='{time_var.units}' "
+            f"and calendar='{calendar}'."
+        ) from exc
+
+    years: list[int] = []
+    for item in decoded:
+        year = getattr(item, "year", None)
+        if year is None:
+            raise ValueError("Decoded time values do not expose a year field.")
+        years.append(int(year))
+
+    return years
+
+
+def annotate_output_file(
+    output_file: str,
+    metdata_type: str,
+    site_metadata_file: Optional[str] = None,
+    era5_metadata_file: Optional[str] = None,
+    variable_name: str = "met_forcing_year",
+) -> Tuple[int, int, int]:
+    if nc is None:
+        raise RuntimeError("netCDF4 is required to annotate output files.")
+
+    metsource, startyear_met, endyear_met_spinup, endyear_met_trans = infer_met_year_ranges(
+        metdata_type=metdata_type,
+        site_metadata_file=site_metadata_file,
+        era5_metadata_file=era5_metadata_file,
+    )
+
+    ds = nc.Dataset(output_file, "r+")
+    try:
+        time_var_name = _detect_time_var_name(ds)
+        years = _extract_simulation_years(ds, time_var_name)
+
+        if len(years) == 0:
+            raise ValueError("Output file has zero timesteps; nothing to annotate.")
+
+        forcing_years = [
+            forcing_year_for_sim_year(
+                sim_year=y,
+                metsource=metsource,
+                startyear_met=startyear_met,
+                endyear_met_spinup=endyear_met_spinup,
+                endyear_met_trans=endyear_met_trans,
+            )
+            for y in years
+        ]
+
+        min_forcing = min(forcing_years)
+        max_forcing = max(forcing_years)
+        if min_forcing < startyear_met or max_forcing > endyear_met_trans:
+            raise ValueError(
+                "Computed forcing years are outside inferred forcing range: "
+                f"computed={min_forcing}..{max_forcing}, "
+                f"expected={startyear_met}..{endyear_met_trans}."
+            )
+
+        time_dim = ds.variables[time_var_name].dimensions[0]
+        if variable_name in ds.variables:
+            out_var = ds.variables[variable_name]
+            if out_var.dimensions != (time_dim,):
+                raise ValueError(
+                    f"Existing variable '{variable_name}' has dimensions {out_var.dimensions}; "
+                    f"expected ({time_dim},)."
+                )
+        else:
+            out_var = ds.createVariable(variable_name, "i4", (time_dim,))
+
+        out_var[:] = forcing_years
+        out_var.long_name = "forcing meteorology year for each model timestep"
+        out_var.units = "year"
+        out_var.source = "metdata_tools/calc_met_forcing_year.py"
+        out_var.metdata_type = metdata_type
+        out_var.metsource = int(metsource)
+        out_var.startyear_met = int(startyear_met)
+        out_var.endyear_met_spinup = int(endyear_met_spinup)
+        out_var.endyear_met_trans = int(endyear_met_trans)
+
+        ds.setncattr("met_forcing_year_variable", variable_name)
+        ds.setncattr("met_forcing_year_source", "metdata_tools/calc_met_forcing_year.py")
+        ds.setncattr("met_forcing_year_metdata_type", metdata_type)
+    finally:
+        ds.close()
+
+    return len(forcing_years), min_forcing, max_forcing
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Write per-timestep forcing years into an ELM output NetCDF file "
+            "using CPL_BYPASS mapping logic from lnd_import_export.F90."
+        )
+    )
+
+    src_group = parser.add_mutually_exclusive_group(required=False)
+    src_group.add_argument(
+        "--metdata-type",
+        type=str,
+        help="metdata_type (for example: gswp3, era5_daymet4, site)",
+    )
+    src_group.add_argument(
+        "--lnd-in",
+        type=str,
+        help="Path to lnd_in; metdata_type/metdata_bypass are read from it",
+    )
+
+    parser.add_argument(
+        "--site-metadata-file",
+        type=str,
+        default=None,
+        help="Path to all_hourly.nc containing start_year/end_year (site forcing)",
+    )
+    parser.add_argument(
+        "--era5-metadata-file",
+        type=str,
+        default=None,
+        help="Path to ERA5 file containing start_year/end_year (optional)",
+    )
+
+    parser.add_argument(
+        "--output-file",
+        type=str,
+        required=True,
+        help="Path to ELM output NetCDF file to annotate in place.",
+    )
+    parser.add_argument(
+        "--variable-name",
+        type=str,
+        default="met_forcing_year",
+        help="Name of the output variable to write (default: met_forcing_year).",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    metdata_type = args.metdata_type
+    if args.lnd_in:
+        parsed = parse_lnd_in(args.lnd_in)
+        if metdata_type is None:
+            metdata_type = parsed.get("metdata_type")
+
+    if not metdata_type:
+        print(
+            "ERROR: metdata_type not provided and not found in --lnd-in.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        nsteps, forcing_min, forcing_max = annotate_output_file(
+            output_file=args.output_file,
+            metdata_type=metdata_type,
+            site_metadata_file=args.site_metadata_file,
+            era5_metadata_file=args.era5_metadata_file,
+            variable_name=args.variable_name,
+        )
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"Annotated file: {args.output_file}")
+    print(f"Variable: {args.variable_name}")
+    print(f"Timesteps annotated: {nsteps}")
+    print(f"Forcing year range in annotations: {forcing_min}..{forcing_max}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/metdata_tools/calc_met_forcing_year.py
+++ b/metdata_tools/calc_met_forcing_year.py
@@ -307,7 +307,8 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Write per-timestep forcing years into an ELM output NetCDF file "
-            "using CPL_BYPASS mapping logic from lnd_import_export.F90."
+            "using CPL_BYPASS mapping logic from lnd_import_export.F90. "
+            "Provide either --lnd-in (preferred) or --metdata-type."
         )
     )
 
@@ -315,25 +316,39 @@ def parse_args() -> argparse.Namespace:
     src_group.add_argument(
         "--metdata-type",
         type=str,
-        help="metdata_type (for example: gswp3, era5_daymet4, site)",
+        help=(
+            "Force metdata type directly (for example: gswp3, era5_daymet4, site). "
+            "Use this when lnd_in is unavailable. If --lnd-in is also provided, "
+            "--metdata-type takes precedence over value parsed from lnd_in."
+        ),
     )
     src_group.add_argument(
         "--lnd-in",
         type=str,
-        help="Path to lnd_in; metdata_type/metdata_bypass are read from it",
+        help=(
+            "Path to lnd_in from the run/case directory (preferred source). "
+            "Used to read metdata_type automatically."
+        ),
     )
 
     parser.add_argument(
         "--site-metadata-file",
         type=str,
         default=None,
-        help="Path to all_hourly.nc containing start_year/end_year (site forcing)",
+        help=(
+            "Path to all_hourly.nc containing start_year/end_year. "
+            "Required when effective metdata_type is site."
+        ),
     )
     parser.add_argument(
         "--era5-metadata-file",
         type=str,
         default=None,
-        help="Path to ERA5 file containing start_year/end_year (optional)",
+        help=(
+            "Optional path to an ERA5 forcing file containing start_year/end_year. "
+            "Used only when effective metdata_type is era5-like and file metadata "
+            "should override built-in defaults."
+        ),
     )
 
     parser.add_argument(
@@ -363,7 +378,7 @@ def main() -> int:
 
     if not metdata_type:
         print(
-            "ERROR: metdata_type not provided and not found in --lnd-in.",
+            "ERROR: Could not determine metdata_type. Provide --metdata-type or a valid --lnd-in.",
             file=sys.stderr,
         )
         return 2

--- a/metdata_tools/plot_forcing_vs_elm_output.py
+++ b/metdata_tools/plot_forcing_vs_elm_output.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Plot forcing meteorology against corresponding ELM history output fields.
 
-This script compares input forcing variables from GSWP3 forcing NetCDF files
+This script compares input forcing variables from met forcing NetCDF files
 against the corresponding ELM history variables for each land gridcell.
 
 If expected output variables are missing, the script prints explicit OLMT
@@ -14,6 +14,7 @@ must be generated first with `calc_met_forcing_year.py`.
 from __future__ import annotations
 
 import argparse
+import glob
 import os
 from dataclasses import dataclass
 from typing import Callable
@@ -35,24 +36,28 @@ class MappingRule:
 
 
 def build_precip_output(ds_out: xr.Dataset, candidates: tuple[str, ...]) -> xr.DataArray:
-    """Build precipitation output signal from RAIN + SNOW when available."""
+    """Build precipitation output signal from required RAIN + SNOW fields."""
     rain_name = candidates[0] if len(candidates) > 0 else "RAIN"
     snow_name = candidates[1] if len(candidates) > 1 else "SNOW"
 
     has_rain = rain_name in ds_out
     has_snow = snow_name in ds_out
 
-    if has_rain and has_snow:
-        arr = ds_out[rain_name] + ds_out[snow_name]
-        arr.attrs["units"] = ds_out[rain_name].attrs.get("units", "")
-        arr.attrs["long_name"] = "RAIN + SNOW"
-        return arr
-    if has_rain:
-        return ds_out[rain_name]
-    if has_snow:
-        return ds_out[snow_name]
+    if not (has_rain and has_snow):
+        missing = []
+        if not has_rain:
+            missing.append(rain_name)
+        if not has_snow:
+            missing.append(snow_name)
+        raise KeyError(
+            "PRECTmms mapping requires both RAIN and SNOW in output dataset; "
+            f"missing: {', '.join(missing)}."
+        )
 
-    raise KeyError("Neither RAIN nor SNOW exists in output dataset.")
+    arr = ds_out[rain_name] + ds_out[snow_name]
+    arr.attrs["units"] = ds_out[rain_name].attrs.get("units", "")
+    arr.attrs["long_name"] = "RAIN + SNOW"
+    return arr
 
 
 def build_single_output(ds_out: xr.Dataset, candidates: tuple[str, ...]) -> xr.DataArray:
@@ -68,48 +73,73 @@ MAPPING_RULES: tuple[MappingRule, ...] = (
     MappingRule("QBOT", ("QBOT",), "Specific humidity", build_single_output),
     MappingRule("FSDS", ("FSDS",), "Downward shortwave radiation", build_single_output),
     MappingRule("FLDS", ("FLDS",), "Downward longwave radiation", build_single_output),
+    # PSRF forcing corresponds to surface pressure, but output naming can vary by config.
+    # Use PBOT first when present; otherwise fall back to PSRF.
     MappingRule("PSRF", ("PBOT", "PSRF"), "Surface pressure", build_single_output),
     MappingRule("WIND", ("WIND",), "Wind speed", build_single_output),
+    # PRECTmms in forcing is total precipitation rate; build output as RAIN + SNOW.
     MappingRule("PRECTmms", ("RAIN", "SNOW"), "Precipitation (RAIN+SNOW)", build_precip_output),
 )
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser.add_argument(
         "--forcing-dir",
-        default="/Users/mhoffman/Documents/PROJECTS/NGEE-Arctic/repos/field-to-model-inputdata/E3SM/atm/datm7/gswp3/kg",
-        help="Directory containing GSWP3 forcing NetCDF files.",
+        help=(
+            "Required. Directory containing forcing NetCDF files. "
+            "No default is applied."
+        ),
     )
     parser.add_argument(
         "--output-file",
-        default="/Users/mhoffman/Documents/PROJECTS/NGEE-Arctic/output/AK-SP-K64G_ICB1850CNPRDCTCBC/run/AK-SP-K64G_ICB1850CNPRDCTCBC.elm.h0.0001-01-01-00000.nc",
-        help="ELM history output NetCDF file.",
+        help=(
+            "Required. ELM history output NetCDF file to compare against forcing. "
+            "No default is applied."
+        ),
     )
     parser.add_argument(
         "--start-date",
         default="",
-        help="Start date (inclusive), format YYYY-MM-DD.",
+        help=(
+            "Optional. Start date (inclusive), format YYYY-MM-DD. "
+            "If omitted (empty string), the script uses the first timestamp in --output-file."
+        ),
     )
     parser.add_argument(
         "--end-date",
         default="",
-        help="End date (inclusive), format YYYY-MM-DD.",
+        help=(
+            "Optional. End date (inclusive), format YYYY-MM-DD. "
+            "If omitted, the script uses the last timestamp in --output-file."
+        ),
     )
     parser.add_argument(
         "--fig-dir",
-        default=os.path.join(os.path.dirname(__file__), "forcing_vs_output_figures"),
-        help="Directory to save generated PNG figures.",
+        default="forcing_vs_output_figures",
+        help=(
+            "Optional. Directory for generated PNG figures and report CSV. "
+            "Default is './forcing_vs_output_figures' relative to the current "
+            "invocation working directory."
+        ),
     )
     parser.add_argument(
         "--vars",
         default="",
-        help="Optional comma-separated forcing variable subset (e.g., TBOT,QBOT,PRECTmms).",
+        help=(
+            "Optional comma-separated forcing variable subset "
+            "(for example: TBOT,QBOT,PRECTmms). "
+            "If omitted, the script processes all supported variables: "
+            "TBOT, QBOT, FSDS, FLDS, PSRF, WIND, PRECTmms."
+        ),
     )
     return parser.parse_args()
 
 
-def standardize_time_dimension(ds: xr.Dataset) -> xr.Dataset:
+def standardize_time_dimension_name(ds: xr.Dataset) -> xr.Dataset:
     """Normalize dataset time dimension to `time` when possible."""
     if "time" in ds.dims or "time" in ds.coords:
         return ds
@@ -128,7 +158,7 @@ def standardize_time_dimension(ds: xr.Dataset) -> xr.Dataset:
 
 def decode_time_and_slice(ds: xr.Dataset, start_date: str, end_date: str) -> xr.Dataset:
     """Decode times and select a date window if possible."""
-    ds = standardize_time_dimension(ds)
+    ds = standardize_time_dimension_name(ds)
     ds = xr.decode_cf(ds)
     if "time" not in ds.coords:
         return ds
@@ -145,8 +175,19 @@ def decode_time_and_slice(ds: xr.Dataset, start_date: str, end_date: str) -> xr.
         return ds
 
 
-def forcing_file_path(forcing_dir: str, forcing_var: str) -> str:
-    return os.path.join(forcing_dir, f"GSWP3_{forcing_var}_1901-2014_z14.nc")
+def forcing_file_path(forcing_dir: str, forcing_var: str) -> str | None:
+    pattern = os.path.join(forcing_dir, f"*_{forcing_var}_*.nc")
+    matches = sorted(glob.glob(pattern))
+
+    if len(matches) > 1:
+        found = ", ".join(matches)
+        raise RuntimeError(
+            f"Expected exactly one forcing file for '{forcing_var}' with pattern '{pattern}', "
+            f"but found {len(matches)}: {found}"
+        )
+    if not matches:
+        return None
+    return matches[0]
 
 
 def normalize_units(unit_str: str) -> str:
@@ -174,22 +215,30 @@ def units_compatible(forcing_units: str, output_units: str) -> bool:
 
 
 def prepare_forcing_series(ds_force: xr.Dataset, forcing_var: str) -> xr.DataArray:
-    """Collapse forcing variable to a 1D time series by averaging spatial dimensions."""
-    arr = ds_force[forcing_var]
-    if "time" not in arr.dims:
-        for dim in arr.dims:
-            if "time" in dim.lower():
-                arr = arr.rename({dim: "time"})
-                break
+    """Return forcing variable as-is; cell selection is handled later per gridcell."""
+    return ds_force[forcing_var]
 
-    for dim in list(arr.dims):
-        if dim != "time":
-            arr = arr.mean(dim=dim)
 
-    if "time" not in arr.dims and len(arr.dims) == 1:
-        arr = arr.rename({arr.dims[0]: "time"})
+def forcing_series_for_gridcell(arr: xr.DataArray, grid_index: int) -> xr.DataArray:
+    """Return 1D forcing series for one gridcell without spatial averaging."""
+    non_time_dims = [dim for dim in arr.dims if dim != "time"]
+    if not non_time_dims:
+        return arr
 
-    return arr
+    stacked = arr.stack(forcing_cell=non_time_dims)
+    return stacked.isel(forcing_cell=grid_index)
+
+
+def count_forcing_cells(arr: xr.DataArray) -> int:
+    """Count forcing gridcells implied by all non-time dimensions."""
+    non_time_dims = [dim for dim in arr.dims if dim != "time"]
+    if not non_time_dims:
+        return 1
+
+    n = 1
+    for dim in non_time_dims:
+        n *= int(arr.sizes[dim])
+    return n
 
 
 def time_to_decimal_year(time_values: np.ndarray) -> np.ndarray:
@@ -239,28 +288,22 @@ def overlap_interval(x1: np.ndarray, x2: np.ndarray) -> tuple[float, float] | No
 
 def series_for_plot(
     arr: xr.DataArray,
-    x_values: np.ndarray | None = None,
-) -> tuple[np.ndarray, np.ndarray, str]:
-    """Return unmodified 1D values with time x-axis when available.
-
-    x_values can be supplied to override the computed x-axis for time values.
-    """
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return unmodified 1D values with required time-coordinate x-axis."""
     if "time" not in arr.dims and len(arr.dims) == 1:
         arr = arr.rename({arr.dims[0]: "time"})
 
     vals = np.atleast_1d(np.asarray(arr.values).squeeze())
     vals = pd.to_numeric(pd.Series(vals), errors="coerce").to_numpy(dtype=float)
 
-    if x_values is not None:
-        xvals = np.atleast_1d(np.asarray(x_values).squeeze())
-        axis_mode = "explicit_mapped_decimal_year"
-    elif "time" in arr.coords:
+    if "time" in arr.coords:
         tvals = np.atleast_1d(np.asarray(arr["time"].values).squeeze())
         xvals = time_to_decimal_year(tvals)
-        axis_mode = "native_time_decimal_year"
     else:
-        xvals = np.arange(vals.size)
-        axis_mode = "native_index"
+        raise ValueError(
+            "Time coordinate is required for plotting. "
+            f"Available coords: {tuple(arr.coords)}"
+        )
 
     if xvals.size != vals.size:
         n = min(xvals.size, vals.size)
@@ -268,7 +311,7 @@ def series_for_plot(
         vals = vals[:n]
 
     mask = np.isfinite(vals)
-    return xvals[mask], vals[mask], axis_mode
+    return xvals[mask], vals[mask]
 
 
 def print_missing_guidance(missing_output: set[str]) -> None:
@@ -359,7 +402,7 @@ def main() -> None:
         selected_vars = {v.strip() for v in args.vars.split(",") if v.strip()}
 
     ds_out = xr.open_dataset(args.output_file, decode_times=False)
-    ds_out = standardize_time_dimension(ds_out)
+    ds_out = standardize_time_dimension_name(ds_out)
     ds_out = xr.decode_cf(ds_out)
 
     start_date = args.start_date
@@ -395,7 +438,7 @@ def main() -> None:
             continue
 
         fpath = forcing_file_path(args.forcing_dir, rule.forcing_var)
-        if not os.path.exists(fpath):
+        if fpath is None:
             report_rows.append(
                 {
                     "forcing_var": rule.forcing_var,
@@ -405,7 +448,10 @@ def main() -> None:
                     "output_units": "",
                     "units_match": False,
                     "alignment": "",
-                    "note": f"Missing forcing file: {fpath}",
+                    "note": (
+                        f"No forcing file found matching pattern: "
+                        f"*_{rule.forcing_var}_*.nc"
+                    ),
                 }
             )
             continue
@@ -414,6 +460,20 @@ def main() -> None:
         ds_force = decode_time_and_slice(ds_force, start_date, end_date)
 
         forcing_arr = prepare_forcing_series(ds_force, rule.forcing_var)
+        if "time" not in forcing_arr.dims:
+            report_rows.append(
+                {
+                    "forcing_var": rule.forcing_var,
+                    "output_var": "",
+                    "status": "invalid_forcing_dims",
+                    "forcing_units": forcing_arr.attrs.get("units", ""),
+                    "output_units": "",
+                    "units_match": False,
+                    "alignment": "",
+                    "note": f"Expected forcing variable to include 'time' dim, found {forcing_arr.dims}",
+                }
+            )
+            continue
 
         try:
             output_arr = rule.output_builder(ds_out, rule.output_candidates)
@@ -454,31 +514,55 @@ def main() -> None:
             continue
 
         ngrid = output_arr.sizes["lndgrid"]
-        plotted = 0
-        forcing_x, forcing_y, forcing_axis_mode = series_for_plot(forcing_arr)
-        forcing_x = forcing_x + forcing_time_shift
-        forcing_axis_mode = f"{forcing_axis_mode}_shifted"
-        if forcing_y.size == 0:
+        forcing_cells = count_forcing_cells(forcing_arr)
+        if forcing_cells not in (1, ngrid):
             report_rows.append(
                 {
                     "forcing_var": rule.forcing_var,
                     "output_var": output_name,
-                    "status": "no_valid_forcing_data",
+                    "status": "forcing_grid_mismatch",
                     "forcing_units": forcing_units,
                     "output_units": output_units,
                     "units_match": match,
                     "alignment": "",
-                    "note": "No finite forcing samples after filtering.",
+                    "note": (
+                        f"Forcing has {forcing_cells} cell(s) across non-time dims {tuple(d for d in forcing_arr.dims if d != 'time')}, "
+                        f"but output has {ngrid} lndgrid cell(s)."
+                    ),
                 }
             )
             continue
 
+        plotted = 0
+        forcing_time_error = False
         for ig in range(ngrid):
             out_g = output_arr.isel(lndgrid=ig)
-            output_x, output_y, output_axis_mode = series_for_plot(
-                out_g,
-                x_values=output_native_x,
-            )
+            force_g = forcing_series_for_gridcell(forcing_arr, 0 if forcing_cells == 1 else ig)
+
+            try:
+                forcing_x, forcing_y = series_for_plot(force_g)
+            except ValueError as exc:
+                report_rows.append(
+                    {
+                        "forcing_var": rule.forcing_var,
+                        "output_var": output_name,
+                        "status": "invalid_forcing_time_coordinate",
+                        "forcing_units": forcing_units,
+                        "output_units": output_units,
+                        "units_match": match,
+                        "alignment": "",
+                        "note": str(exc),
+                    }
+                )
+                plotted = 0
+                forcing_time_error = True
+                break
+
+            forcing_x = forcing_x + forcing_time_shift
+            if forcing_y.size == 0:
+                continue
+
+            output_x, output_y = series_for_plot(out_g)
             if output_y.size == 0:
                 continue
 
@@ -504,8 +588,13 @@ def main() -> None:
             plt.close(fig)
             plotted += 1
 
+        if forcing_time_error:
+            continue
+
         status = "plotted" if plotted > 0 else "no_overlap_after_alignment"
-        alignment_mode = f"forcing:{forcing_axis_mode}|output:{output_axis_mode}"
+        if plotted == 0:
+            status = "no_valid_forcing_data"
+        alignment_mode = "forcing:time_shifted_to_output|output:native_time"
         note = (
             "No downsampling or truncation. Output is shown on native output-file "
             "time range, and forcing time is shifted using met_forcing_year-derived "

--- a/metdata_tools/plot_forcing_vs_elm_output.py
+++ b/metdata_tools/plot_forcing_vs_elm_output.py
@@ -121,7 +121,7 @@ def parse_args() -> argparse.Namespace:
         "--fig-dir",
         default="forcing_vs_output_figures",
         help=(
-            "Optional. Directory for generated PNG figures and report CSV. "
+            "Optional. Directory for generated PNG figures. "
             "Default is './forcing_vs_output_figures' relative to the current "
             "invocation working directory."
         ),
@@ -188,30 +188,6 @@ def forcing_file_path(forcing_dir: str, forcing_var: str) -> str | None:
     if not matches:
         return None
     return matches[0]
-
-
-def normalize_units(unit_str: str) -> str:
-    cleaned = (unit_str or "").strip()
-    return cleaned.replace("^", "")
-
-
-def units_compatible(forcing_units: str, output_units: str) -> bool:
-    fu = normalize_units(forcing_units)
-    ou = normalize_units(output_units)
-    compatible_pairs = {
-        ("W/m2", "W/m2"),
-        ("W/m2", "W/m2"),
-        ("W/m2", "W/m^2"),
-        ("W/m^2", "W/m2"),
-        ("Pa", "Pa"),
-        ("K", "K"),
-        ("kg/kg", "kg/kg"),
-        ("m/s", "m/s"),
-        ("mm/s", "mm/s"),
-    }
-    if fu == ou:
-        return True
-    return (fu, ou) in compatible_pairs
 
 
 def prepare_forcing_series(ds_force: xr.Dataset, forcing_var: str) -> xr.DataArray:
@@ -430,7 +406,6 @@ def main() -> None:
     if output_window is not None:
         output_left, output_right = output_window
 
-    report_rows: list[dict[str, object]] = []
     missing_output: set[str] = set()
 
     for rule in MAPPING_RULES:
@@ -439,20 +414,9 @@ def main() -> None:
 
         fpath = forcing_file_path(args.forcing_dir, rule.forcing_var)
         if fpath is None:
-            report_rows.append(
-                {
-                    "forcing_var": rule.forcing_var,
-                    "output_var": "",
-                    "status": "forcing_file_missing",
-                    "forcing_units": "",
-                    "output_units": "",
-                    "units_match": False,
-                    "alignment": "",
-                    "note": (
-                        f"No forcing file found matching pattern: "
-                        f"*_{rule.forcing_var}_*.nc"
-                    ),
-                }
+            print(
+                f"Skipping {rule.forcing_var}: no forcing file found matching pattern "
+                f"*_{rule.forcing_var}_*.nc"
             )
             continue
 
@@ -461,17 +425,9 @@ def main() -> None:
 
         forcing_arr = prepare_forcing_series(ds_force, rule.forcing_var)
         if "time" not in forcing_arr.dims:
-            report_rows.append(
-                {
-                    "forcing_var": rule.forcing_var,
-                    "output_var": "",
-                    "status": "invalid_forcing_dims",
-                    "forcing_units": forcing_arr.attrs.get("units", ""),
-                    "output_units": "",
-                    "units_match": False,
-                    "alignment": "",
-                    "note": f"Expected forcing variable to include 'time' dim, found {forcing_arr.dims}",
-                }
+            print(
+                f"Skipping {rule.forcing_var}: expected forcing variable to include "
+                f"'time' dim, found {forcing_arr.dims}"
             )
             continue
 
@@ -480,56 +436,29 @@ def main() -> None:
             output_name = output_arr.name if output_arr.name else "+".join(rule.output_candidates)
         except KeyError:
             missing_output.update(rule.output_candidates)
-            report_rows.append(
-                {
-                    "forcing_var": rule.forcing_var,
-                    "output_var": ",".join(rule.output_candidates),
-                    "status": "missing_output_variable",
-                    "forcing_units": forcing_arr.attrs.get("units", ""),
-                    "output_units": "",
-                    "units_match": False,
-                    "alignment": "",
-                    "note": "No candidate output variable found.",
-                }
+            print(
+                f"Skipping {rule.forcing_var}: missing output variable(s) "
+                f"{','.join(rule.output_candidates)}"
             )
             continue
 
         forcing_units = forcing_arr.attrs.get("units", "")
         output_units = output_arr.attrs.get("units", "")
-        match = units_compatible(forcing_units, output_units)
 
         if "lndgrid" not in output_arr.dims:
-            report_rows.append(
-                {
-                    "forcing_var": rule.forcing_var,
-                    "output_var": output_name,
-                    "status": "invalid_output_dims",
-                    "forcing_units": forcing_units,
-                    "output_units": output_units,
-                    "units_match": match,
-                    "alignment": "",
-                    "note": f"Expected lndgrid dim, found {output_arr.dims}",
-                }
+            print(
+                f"Skipping {rule.forcing_var}: expected output variable {output_name} "
+                f"to include lndgrid dim, found {output_arr.dims}"
             )
             continue
 
         ngrid = output_arr.sizes["lndgrid"]
         forcing_cells = count_forcing_cells(forcing_arr)
         if forcing_cells not in (1, ngrid):
-            report_rows.append(
-                {
-                    "forcing_var": rule.forcing_var,
-                    "output_var": output_name,
-                    "status": "forcing_grid_mismatch",
-                    "forcing_units": forcing_units,
-                    "output_units": output_units,
-                    "units_match": match,
-                    "alignment": "",
-                    "note": (
-                        f"Forcing has {forcing_cells} cell(s) across non-time dims {tuple(d for d in forcing_arr.dims if d != 'time')}, "
-                        f"but output has {ngrid} lndgrid cell(s)."
-                    ),
-                }
+            print(
+                f"Skipping {rule.forcing_var}: forcing has {forcing_cells} cell(s) "
+                f"across non-time dims {tuple(d for d in forcing_arr.dims if d != 'time')}, "
+                f"but output has {ngrid} lndgrid cell(s)."
             )
             continue
 
@@ -542,18 +471,7 @@ def main() -> None:
             try:
                 forcing_x, forcing_y = series_for_plot(force_g)
             except ValueError as exc:
-                report_rows.append(
-                    {
-                        "forcing_var": rule.forcing_var,
-                        "output_var": output_name,
-                        "status": "invalid_forcing_time_coordinate",
-                        "forcing_units": forcing_units,
-                        "output_units": output_units,
-                        "units_match": match,
-                        "alignment": "",
-                        "note": str(exc),
-                    }
-                )
+                print(f"Skipping {rule.forcing_var}: {exc}")
                 plotted = 0
                 forcing_time_error = True
                 break
@@ -591,37 +509,13 @@ def main() -> None:
         if forcing_time_error:
             continue
 
-        status = "plotted" if plotted > 0 else "no_overlap_after_alignment"
         if plotted == 0:
-            status = "no_valid_forcing_data"
-        alignment_mode = "forcing:time_shifted_to_output|output:native_time"
-        note = (
-            "No downsampling or truncation. Output is shown on native output-file "
-            "time range, and forcing time is shifted using met_forcing_year-derived "
-            f"offset ({forcing_time_shift:+.6f} years)."
-        )
-
-        report_rows.append(
-            {
-                "forcing_var": rule.forcing_var,
-                "output_var": output_name,
-                "status": status,
-                "forcing_units": forcing_units,
-                "output_units": output_units,
-                "units_match": match,
-                "alignment": alignment_mode,
-                "note": note,
-                "n_gridcells_plotted": plotted,
-            }
-        )
-
-    report_path = os.path.join(args.fig_dir, "forcing_output_mapping_report.csv")
-    report = pd.DataFrame(report_rows)
-    report.to_csv(report_path, index=False)
-
-    print(f"Saved report: {report_path}")
-    if not report.empty:
-        print(report[["forcing_var", "output_var", "status", "units_match", "alignment", "note"]].to_string(index=False))
+            print(f"No valid overlapping samples to plot for {rule.forcing_var} vs {output_name}.")
+        else:
+            print(
+                f"Plotted {plotted} gridcell(s) for {rule.forcing_var} vs {output_name} "
+                f"(forcing shifted by {forcing_time_shift:+.6f} years)."
+            )
 
     print_missing_guidance(missing_output)
 

--- a/metdata_tools/plot_forcing_vs_elm_output.py
+++ b/metdata_tools/plot_forcing_vs_elm_output.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+"""Plot forcing meteorology against corresponding ELM history output fields.
+
+This script compares input forcing variables from GSWP3 forcing NetCDF files
+against the corresponding ELM history variables for each land gridcell.
+
+If expected output variables are missing, the script prints explicit OLMT
+`site_fullrun.py` guidance for adding them to transient history output.
+
+This script requires `met_forcing_year` to exist in the output file. That field
+must be generated first with `calc_met_forcing_year.py`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from typing import Callable
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+
+@dataclass(frozen=True)
+class MappingRule:
+    forcing_var: str
+    output_candidates: tuple[str, ...]
+    description: str
+    output_builder: Callable[[xr.Dataset, tuple[str, ...]], xr.DataArray]
+
+
+def build_precip_output(ds_out: xr.Dataset, candidates: tuple[str, ...]) -> xr.DataArray:
+    """Build precipitation output signal from RAIN + SNOW when available."""
+    rain_name = candidates[0] if len(candidates) > 0 else "RAIN"
+    snow_name = candidates[1] if len(candidates) > 1 else "SNOW"
+
+    has_rain = rain_name in ds_out
+    has_snow = snow_name in ds_out
+
+    if has_rain and has_snow:
+        arr = ds_out[rain_name] + ds_out[snow_name]
+        arr.attrs["units"] = ds_out[rain_name].attrs.get("units", "")
+        arr.attrs["long_name"] = "RAIN + SNOW"
+        return arr
+    if has_rain:
+        return ds_out[rain_name]
+    if has_snow:
+        return ds_out[snow_name]
+
+    raise KeyError("Neither RAIN nor SNOW exists in output dataset.")
+
+
+def build_single_output(ds_out: xr.Dataset, candidates: tuple[str, ...]) -> xr.DataArray:
+    """Return first available candidate variable in output dataset."""
+    for name in candidates:
+        if name in ds_out:
+            return ds_out[name]
+    raise KeyError(f"None of {candidates} found in output dataset.")
+
+
+MAPPING_RULES: tuple[MappingRule, ...] = (
+    MappingRule("TBOT", ("TBOT",), "Air temperature", build_single_output),
+    MappingRule("QBOT", ("QBOT",), "Specific humidity", build_single_output),
+    MappingRule("FSDS", ("FSDS",), "Downward shortwave radiation", build_single_output),
+    MappingRule("FLDS", ("FLDS",), "Downward longwave radiation", build_single_output),
+    MappingRule("PSRF", ("PBOT", "PSRF"), "Surface pressure", build_single_output),
+    MappingRule("WIND", ("WIND",), "Wind speed", build_single_output),
+    MappingRule("PRECTmms", ("RAIN", "SNOW"), "Precipitation (RAIN+SNOW)", build_precip_output),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--forcing-dir",
+        default="/Users/mhoffman/Documents/PROJECTS/NGEE-Arctic/repos/field-to-model-inputdata/E3SM/atm/datm7/gswp3/kg",
+        help="Directory containing GSWP3 forcing NetCDF files.",
+    )
+    parser.add_argument(
+        "--output-file",
+        default="/Users/mhoffman/Documents/PROJECTS/NGEE-Arctic/output/AK-SP-K64G_ICB1850CNPRDCTCBC/run/AK-SP-K64G_ICB1850CNPRDCTCBC.elm.h0.0001-01-01-00000.nc",
+        help="ELM history output NetCDF file.",
+    )
+    parser.add_argument(
+        "--start-date",
+        default="",
+        help="Start date (inclusive), format YYYY-MM-DD.",
+    )
+    parser.add_argument(
+        "--end-date",
+        default="",
+        help="End date (inclusive), format YYYY-MM-DD.",
+    )
+    parser.add_argument(
+        "--fig-dir",
+        default=os.path.join(os.path.dirname(__file__), "forcing_vs_output_figures"),
+        help="Directory to save generated PNG figures.",
+    )
+    parser.add_argument(
+        "--vars",
+        default="",
+        help="Optional comma-separated forcing variable subset (e.g., TBOT,QBOT,PRECTmms).",
+    )
+    return parser.parse_args()
+
+
+def standardize_time_dimension(ds: xr.Dataset) -> xr.Dataset:
+    """Normalize dataset time dimension to `time` when possible."""
+    if "time" in ds.dims or "time" in ds.coords:
+        return ds
+
+    if "DTIME" in ds.dims or "DTIME" in ds.coords or "DTIME" in ds.variables:
+        if "DTIME" in ds.variables and "DTIME" not in ds.coords:
+            ds = ds.set_coords("DTIME")
+        return ds.rename({"DTIME": "time"})
+
+    for dim in ds.dims:
+        if "time" in dim.lower():
+            return ds.rename({dim: "time"})
+
+    return ds
+
+
+def decode_time_and_slice(ds: xr.Dataset, start_date: str, end_date: str) -> xr.Dataset:
+    """Decode times and select a date window if possible."""
+    ds = standardize_time_dimension(ds)
+    ds = xr.decode_cf(ds)
+    if "time" not in ds.coords:
+        return ds
+
+    if not start_date or not end_date:
+        return ds
+
+    try:
+        sliced = ds.sel(time=slice(start_date, end_date))
+        if sliced.sizes.get("time", 0) == 0:
+            return ds
+        return sliced
+    except Exception:
+        return ds
+
+
+def forcing_file_path(forcing_dir: str, forcing_var: str) -> str:
+    return os.path.join(forcing_dir, f"GSWP3_{forcing_var}_1901-2014_z14.nc")
+
+
+def normalize_units(unit_str: str) -> str:
+    cleaned = (unit_str or "").strip()
+    return cleaned.replace("^", "")
+
+
+def units_compatible(forcing_units: str, output_units: str) -> bool:
+    fu = normalize_units(forcing_units)
+    ou = normalize_units(output_units)
+    compatible_pairs = {
+        ("W/m2", "W/m2"),
+        ("W/m2", "W/m2"),
+        ("W/m2", "W/m^2"),
+        ("W/m^2", "W/m2"),
+        ("Pa", "Pa"),
+        ("K", "K"),
+        ("kg/kg", "kg/kg"),
+        ("m/s", "m/s"),
+        ("mm/s", "mm/s"),
+    }
+    if fu == ou:
+        return True
+    return (fu, ou) in compatible_pairs
+
+
+def prepare_forcing_series(ds_force: xr.Dataset, forcing_var: str) -> xr.DataArray:
+    """Collapse forcing variable to a 1D time series by averaging spatial dimensions."""
+    arr = ds_force[forcing_var]
+    if "time" not in arr.dims:
+        for dim in arr.dims:
+            if "time" in dim.lower():
+                arr = arr.rename({dim: "time"})
+                break
+
+    for dim in list(arr.dims):
+        if dim != "time":
+            arr = arr.mean(dim=dim)
+
+    if "time" not in arr.dims and len(arr.dims) == 1:
+        arr = arr.rename({arr.dims[0]: "time"})
+
+    return arr
+
+
+def time_to_decimal_year(time_values: np.ndarray) -> np.ndarray:
+    """Convert datetime-like values (including cftime) to decimal year."""
+    dec = np.empty(len(time_values), dtype=float)
+    for i, t in enumerate(time_values):
+        year = getattr(t, "year", None)
+        if year is None:
+            ts = pd.Timestamp(t)
+            year = ts.year
+            doy = ts.dayofyear
+            hour = ts.hour
+            minute = ts.minute
+            second = ts.second
+            microsecond = ts.microsecond
+            days_in_year = 366 if ts.is_leap_year else 365
+        else:
+            doy = getattr(t, "dayofyr", None)
+            if doy is None:
+                doy = t.timetuple().tm_yday
+            hour = getattr(t, "hour", 0)
+            minute = getattr(t, "minute", 0)
+            second = getattr(t, "second", 0)
+            microsecond = getattr(t, "microsecond", 0)
+            days_in_year = 366 if getattr(t, "is_leap_year", lambda: False)() else 365
+
+        frac_day = (hour + minute / 60.0 + second / 3600.0 + microsecond / 3.6e9) / 24.0
+        dec[i] = year + ((doy - 1) + frac_day) / days_in_year
+
+    return dec
+
+
+def overlap_interval(x1: np.ndarray, x2: np.ndarray) -> tuple[float, float] | None:
+    """Return overlap interval [left, right] for two finite x arrays."""
+    if x1.size == 0 or x2.size == 0:
+        return None
+    x1f = x1[np.isfinite(x1)]
+    x2f = x2[np.isfinite(x2)]
+    if x1f.size == 0 or x2f.size == 0:
+        return None
+    left = max(float(np.min(x1f)), float(np.min(x2f)))
+    right = min(float(np.max(x1f)), float(np.max(x2f)))
+    if left <= right:
+        return (left, right)
+    return None
+
+
+def series_for_plot(
+    arr: xr.DataArray,
+    x_values: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray, str]:
+    """Return unmodified 1D values with time x-axis when available.
+
+    x_values can be supplied to override the computed x-axis for time values.
+    """
+    if "time" not in arr.dims and len(arr.dims) == 1:
+        arr = arr.rename({arr.dims[0]: "time"})
+
+    vals = np.atleast_1d(np.asarray(arr.values).squeeze())
+    vals = pd.to_numeric(pd.Series(vals), errors="coerce").to_numpy(dtype=float)
+
+    if x_values is not None:
+        xvals = np.atleast_1d(np.asarray(x_values).squeeze())
+        axis_mode = "explicit_mapped_decimal_year"
+    elif "time" in arr.coords:
+        tvals = np.atleast_1d(np.asarray(arr["time"].values).squeeze())
+        xvals = time_to_decimal_year(tvals)
+        axis_mode = "native_time_decimal_year"
+    else:
+        xvals = np.arange(vals.size)
+        axis_mode = "native_index"
+
+    if xvals.size != vals.size:
+        n = min(xvals.size, vals.size)
+        xvals = xvals[:n]
+        vals = vals[:n]
+
+    mask = np.isfinite(vals)
+    return xvals[mask], vals[mask], axis_mode
+
+
+def print_missing_guidance(missing_output: set[str]) -> None:
+    if not missing_output:
+        return
+
+    suggested = [
+        "TBOT",
+        "QBOT",
+        "FSDS",
+        "FLDS",
+        "PBOT",
+        "WIND",
+        "RAIN",
+        "SNOW",
+    ]
+    needed = [v for v in suggested if v in missing_output]
+    if not needed:
+        return
+
+    varlist = ",".join(needed)
+    print("\nMissing output fields detected.")
+    print("To include them via OLMT, add to transient history var list.")
+    print("Example:")
+    print(f"  --trans_varlist \"{varlist}\"")
+    print("Notes:")
+    print("  - In forcing, PSRF corresponds to PBOT on ELM history output.")
+    print("  - If comparing PRECTmms, include both RAIN and SNOW.")
+    print("  - Internally, OLMT writes hist_empty_htapes=.true. and hist_fincl1 from --trans_varlist.")
+
+
+def build_output_mapped_decimal_year(ds_out: xr.Dataset, forcing_year_var: str) -> np.ndarray:
+    """Build decimal-year x-axis using met_forcing_year + output intra-year fraction."""
+    if forcing_year_var not in ds_out:
+        raise KeyError(
+            f"Required variable '{forcing_year_var}' not found in output file. "
+            "Run calc_met_forcing_year.py first."
+        )
+    if "time" not in ds_out.coords:
+        raise KeyError("Output file has no decodable time coordinate.")
+
+    dec_time = time_to_decimal_year(np.asarray(ds_out["time"].values))
+    year_frac = dec_time - np.floor(dec_time)
+
+    forcing_year = np.asarray(ds_out[forcing_year_var].values).squeeze()
+    if forcing_year.ndim != 1:
+        raise ValueError(
+            f"Expected '{forcing_year_var}' to be 1D over time, got shape {forcing_year.shape}."
+        )
+    if forcing_year.size != year_frac.size:
+        raise ValueError(
+            f"Length mismatch between '{forcing_year_var}' ({forcing_year.size}) and time ({year_frac.size})."
+        )
+
+    forcing_year = pd.to_numeric(pd.Series(forcing_year), errors="coerce").to_numpy(dtype=float)
+    return forcing_year + year_frac
+
+
+def build_output_native_decimal_year(ds_out: xr.Dataset) -> np.ndarray:
+    """Build decimal-year x-axis directly from output file time coordinate."""
+    if "time" not in ds_out.coords:
+        raise KeyError("Output file has no decodable time coordinate.")
+    return time_to_decimal_year(np.asarray(ds_out["time"].values))
+
+
+def derive_forcing_time_shift(
+    output_native_x: np.ndarray,
+    output_mapped_x: np.ndarray,
+) -> float:
+    """Derive a constant shift so forcing-year axis overlays output-year axis."""
+    if output_native_x.size == 0 or output_mapped_x.size == 0:
+        return 0.0
+    n = min(output_native_x.size, output_mapped_x.size)
+    delta = output_native_x[:n] - output_mapped_x[:n]
+    delta = delta[np.isfinite(delta)]
+    if delta.size == 0:
+        return 0.0
+    return float(np.median(delta))
+
+
+def main() -> None:
+    args = parse_args()
+    os.makedirs(args.fig_dir, exist_ok=True)
+    forcing_year_var = "met_forcing_year"
+
+    selected_vars = None
+    if args.vars.strip():
+        selected_vars = {v.strip() for v in args.vars.split(",") if v.strip()}
+
+    ds_out = xr.open_dataset(args.output_file, decode_times=False)
+    ds_out = standardize_time_dimension(ds_out)
+    ds_out = xr.decode_cf(ds_out)
+
+    start_date = args.start_date
+    end_date = args.end_date
+    if (not start_date or not end_date) and "time" in ds_out.coords and ds_out.sizes.get("time", 0) > 0:
+        time_vals = ds_out["time"].values
+        start_date = str(time_vals[0])[:10]
+        end_date = str(time_vals[-1])[:10]
+        print(f"Using output-file time bounds as defaults: {start_date} to {end_date}")
+
+    ds_out = decode_time_and_slice(ds_out, start_date, end_date)
+
+    if forcing_year_var not in ds_out:
+        raise SystemExit(
+            "Required field 'met_forcing_year' is missing from output file. "
+            "Run metdata_tools/calc_met_forcing_year.py --output-file <elm_output.nc> first."
+        )
+
+    output_mapped_x = build_output_mapped_decimal_year(ds_out, forcing_year_var)
+    output_native_x = build_output_native_decimal_year(ds_out)
+    forcing_time_shift = derive_forcing_time_shift(output_native_x, output_mapped_x)
+
+    output_window = overlap_interval(output_native_x, output_native_x)
+    output_left, output_right = (None, None)
+    if output_window is not None:
+        output_left, output_right = output_window
+
+    report_rows: list[dict[str, object]] = []
+    missing_output: set[str] = set()
+
+    for rule in MAPPING_RULES:
+        if selected_vars is not None and rule.forcing_var not in selected_vars:
+            continue
+
+        fpath = forcing_file_path(args.forcing_dir, rule.forcing_var)
+        if not os.path.exists(fpath):
+            report_rows.append(
+                {
+                    "forcing_var": rule.forcing_var,
+                    "output_var": "",
+                    "status": "forcing_file_missing",
+                    "forcing_units": "",
+                    "output_units": "",
+                    "units_match": False,
+                    "alignment": "",
+                    "note": f"Missing forcing file: {fpath}",
+                }
+            )
+            continue
+
+        ds_force = xr.open_dataset(fpath, decode_times=False)
+        ds_force = decode_time_and_slice(ds_force, start_date, end_date)
+
+        forcing_arr = prepare_forcing_series(ds_force, rule.forcing_var)
+
+        try:
+            output_arr = rule.output_builder(ds_out, rule.output_candidates)
+            output_name = output_arr.name if output_arr.name else "+".join(rule.output_candidates)
+        except KeyError:
+            missing_output.update(rule.output_candidates)
+            report_rows.append(
+                {
+                    "forcing_var": rule.forcing_var,
+                    "output_var": ",".join(rule.output_candidates),
+                    "status": "missing_output_variable",
+                    "forcing_units": forcing_arr.attrs.get("units", ""),
+                    "output_units": "",
+                    "units_match": False,
+                    "alignment": "",
+                    "note": "No candidate output variable found.",
+                }
+            )
+            continue
+
+        forcing_units = forcing_arr.attrs.get("units", "")
+        output_units = output_arr.attrs.get("units", "")
+        match = units_compatible(forcing_units, output_units)
+
+        if "lndgrid" not in output_arr.dims:
+            report_rows.append(
+                {
+                    "forcing_var": rule.forcing_var,
+                    "output_var": output_name,
+                    "status": "invalid_output_dims",
+                    "forcing_units": forcing_units,
+                    "output_units": output_units,
+                    "units_match": match,
+                    "alignment": "",
+                    "note": f"Expected lndgrid dim, found {output_arr.dims}",
+                }
+            )
+            continue
+
+        ngrid = output_arr.sizes["lndgrid"]
+        plotted = 0
+        forcing_x, forcing_y, forcing_axis_mode = series_for_plot(forcing_arr)
+        forcing_x = forcing_x + forcing_time_shift
+        forcing_axis_mode = f"{forcing_axis_mode}_shifted"
+        if forcing_y.size == 0:
+            report_rows.append(
+                {
+                    "forcing_var": rule.forcing_var,
+                    "output_var": output_name,
+                    "status": "no_valid_forcing_data",
+                    "forcing_units": forcing_units,
+                    "output_units": output_units,
+                    "units_match": match,
+                    "alignment": "",
+                    "note": "No finite forcing samples after filtering.",
+                }
+            )
+            continue
+
+        for ig in range(ngrid):
+            out_g = output_arr.isel(lndgrid=ig)
+            output_x, output_y, output_axis_mode = series_for_plot(
+                out_g,
+                x_values=output_native_x,
+            )
+            if output_y.size == 0:
+                continue
+
+            fig, ax = plt.subplots(figsize=(12, 4))
+            ax.plot(forcing_x, forcing_y, label=f"forcing:{rule.forcing_var}", lw=1.6, color="k")
+            ax.plot(output_x, output_y, label=f"output:{output_name} (grid {ig})", lw=1.2)
+            if output_left is not None and output_right is not None:
+                if output_right > output_left:
+                    ax.set_xlim(output_left, output_right)
+                else:
+                    pad = 1.0 / 365.0
+                    ax.set_xlim(output_left - pad, output_right + pad)
+
+            ax.set_title(f"{rule.description} | gridcell {ig}")
+            ax.set_xlabel("Time (decimal year)")
+            ax.set_ylabel(f"forcing [{forcing_units}] vs output [{output_units}]")
+            ax.grid(True, alpha=0.35)
+            ax.legend(loc="best")
+            plt.tight_layout()
+
+            png_name = f"{rule.forcing_var}_vs_{output_name}_grid{ig:03d}.png"
+            fig.savefig(os.path.join(args.fig_dir, png_name), dpi=150)
+            plt.close(fig)
+            plotted += 1
+
+        status = "plotted" if plotted > 0 else "no_overlap_after_alignment"
+        alignment_mode = f"forcing:{forcing_axis_mode}|output:{output_axis_mode}"
+        note = (
+            "No downsampling or truncation. Output is shown on native output-file "
+            "time range, and forcing time is shifted using met_forcing_year-derived "
+            f"offset ({forcing_time_shift:+.6f} years)."
+        )
+
+        report_rows.append(
+            {
+                "forcing_var": rule.forcing_var,
+                "output_var": output_name,
+                "status": status,
+                "forcing_units": forcing_units,
+                "output_units": output_units,
+                "units_match": match,
+                "alignment": alignment_mode,
+                "note": note,
+                "n_gridcells_plotted": plotted,
+            }
+        )
+
+    report_path = os.path.join(args.fig_dir, "forcing_output_mapping_report.csv")
+    report = pd.DataFrame(report_rows)
+    report.to_csv(report_path, index=False)
+
+    print(f"Saved report: {report_path}")
+    if not report.empty:
+        print(report[["forcing_var", "output_var", "status", "units_match", "alignment", "note"]].to_string(index=False))
+
+    print_missing_guidance(missing_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/metdata_tools/plot_forcing_vs_elm_output.py
+++ b/metdata_tools/plot_forcing_vs_elm_output.py
@@ -136,6 +136,16 @@ def parse_args() -> argparse.Namespace:
             "TBOT, QBOT, FSDS, FLDS, PSRF, WIND, PRECTmms."
         ),
     )
+    parser.add_argument(
+        "--forcing-time-mode",
+        choices=("native", "average_to_output"),
+        default="native",
+        help=(
+            "How to represent forcing in time. 'native' plots forcing at its native "
+            "timestep (after year-shift alignment). 'average_to_output' averages forcing "
+            "within each output-time interval and plots at output timestamps."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -290,6 +300,54 @@ def series_for_plot(
     return xvals[mask], vals[mask]
 
 
+def average_series_to_target_intervals(
+    source_x: np.ndarray,
+    source_y: np.ndarray,
+    target_x: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Average source series into trailing intervals ending at target timestamps.
+
+    This assumes target timestamps represent end-of-interval output writes.
+    """
+    if source_x.size == 0 or source_y.size == 0 or target_x.size == 0:
+        return np.array([], dtype=float), np.array([], dtype=float)
+
+    sx = np.asarray(source_x, dtype=float)
+    sy = np.asarray(source_y, dtype=float)
+    tx = np.asarray(target_x, dtype=float)
+
+    finite = np.isfinite(sx) & np.isfinite(sy)
+    sx = sx[finite]
+    sy = sy[finite]
+    if sx.size == 0:
+        return np.array([], dtype=float), np.array([], dtype=float)
+
+    order = np.argsort(sx)
+    sx = sx[order]
+    sy = sy[order]
+
+    if tx.size == 1:
+        return np.array([tx[0]], dtype=float), np.array([float(np.mean(sy))], dtype=float)
+
+    # Build trailing bin edges so bin i is (edge_i, target_i], matching
+    # end-stamped output convention and avoiding half-step centering lag.
+    edges = np.empty(tx.size + 1, dtype=float)
+    edges[1:] = tx
+    edges[0] = tx[0] - (tx[1] - tx[0])
+
+    out_y = np.full(tx.shape, np.nan, dtype=float)
+    for i in range(tx.size):
+        if i == 0:
+            in_bin = (sx >= edges[i]) & (sx <= edges[i + 1])
+        else:
+            in_bin = (sx > edges[i]) & (sx <= edges[i + 1])
+        if np.any(in_bin):
+            out_y[i] = float(np.mean(sy[in_bin]))
+
+    keep = np.isfinite(out_y)
+    return tx[keep], out_y[keep]
+
+
 def print_missing_guidance(missing_output: set[str]) -> None:
     if not missing_output:
         return
@@ -368,6 +426,21 @@ def derive_forcing_time_shift(
     return float(np.median(delta))
 
 
+def derive_output_interval(output_native_x: np.ndarray) -> float:
+    """Estimate one output interval in decimal-year units from output timestamps."""
+    if output_native_x.size < 2:
+        return 0.0
+    x = np.asarray(output_native_x, dtype=float)
+    x = x[np.isfinite(x)]
+    if x.size < 2:
+        return 0.0
+    dx = np.diff(x)
+    dx = dx[np.isfinite(dx) & (dx > 0.0)]
+    if dx.size == 0:
+        return 0.0
+    return float(np.median(dx))
+
+
 def main() -> None:
     args = parse_args()
     os.makedirs(args.fig_dir, exist_ok=True)
@@ -400,6 +473,8 @@ def main() -> None:
     output_mapped_x = build_output_mapped_decimal_year(ds_out, forcing_year_var)
     output_native_x = build_output_native_decimal_year(ds_out)
     forcing_time_shift = derive_forcing_time_shift(output_native_x, output_mapped_x)
+    output_interval_shift = derive_output_interval(output_native_x) * 1.5
+    output_interval_shift_days = output_interval_shift * 365.25
 
     output_window = overlap_interval(output_native_x, output_native_x)
     output_left, output_right = (None, None)
@@ -468,6 +543,10 @@ def main() -> None:
             out_g = output_arr.isel(lndgrid=ig)
             force_g = forcing_series_for_gridcell(forcing_arr, 0 if forcing_cells == 1 else ig)
 
+            output_x, output_y = series_for_plot(out_g)
+            if output_y.size == 0:
+                continue
+
             try:
                 forcing_x, forcing_y = series_for_plot(force_g)
             except ValueError as exc:
@@ -480,9 +559,16 @@ def main() -> None:
             if forcing_y.size == 0:
                 continue
 
-            output_x, output_y = series_for_plot(out_g)
-            if output_y.size == 0:
-                continue
+            if args.forcing_time_mode == "average_to_output":
+                forcing_x, forcing_y = average_series_to_target_intervals(
+                    forcing_x,
+                    forcing_y,
+                    output_x,
+                )
+                if forcing_y.size == 0:
+                    continue
+
+            forcing_x = forcing_x + output_interval_shift
 
             fig, ax = plt.subplots(figsize=(12, 4))
             ax.plot(forcing_x, forcing_y, label=f"forcing:{rule.forcing_var}", lw=1.6, color="k")
@@ -514,7 +600,8 @@ def main() -> None:
         else:
             print(
                 f"Plotted {plotted} gridcell(s) for {rule.forcing_var} vs {output_name} "
-                f"(forcing shifted by {forcing_time_shift:+.6f} years)."
+                f"(forcing mode: {args.forcing_time_mode}; shifted by {forcing_time_shift:+.6f} years "
+                f"+ 1.5x output interval {output_interval_shift_days:+.3f} days)."
             )
 
     print_missing_guidance(missing_output)


### PR DESCRIPTION
This PR adds two new utilities to support reliable comparison between meteorological forcing files and ELM history output:

* calc_met_forcing_year.py: annotates ELM output with forcing-year metadata.
* plot_forcing_vs_elm_output.py: plots forcing variables against corresponding ELM output variables on aligned time axes.

Together, these scripts make forcing/output alignment explicit and reproducible, especially for cycling and transient forcing workflows.

Motivation
Comparing forcing and model output was error-prone because time alignment depended on implicit assumptions (cycle year mapping, timestamp conventions, variable naming, and output field availability).  This PR makes alignment explicit by writing forcing-year metadata into output and requiring that metadata in the plotting workflow.