### PR TITLE
Fix a few arguments not working as intended

### DIFF
--- a/global_fullrun.py
+++ b/global_fullrun.py
@@ -816,7 +816,7 @@ if options.runroot == "":
         runroot = csmdir + "/run"
 else:
     runroot = os.path.abspath(options.runroot)
-if options.caseroot == "" or (not os.path.exists(options.caseroot)):
+if options.caseroot == "":
     caseroot = os.path.abspath(csmdir + "/cime/scripts")
 else:
     caseroot = os.path.abspath(options.caseroot)

--- a/global_fullrun.py
+++ b/global_fullrun.py
@@ -820,6 +820,7 @@ if options.caseroot == "":
     caseroot = os.path.abspath(csmdir + "/cime/scripts")
 else:
     caseroot = os.path.abspath(options.caseroot)
+    os.system("mkdir -p " + caseroot)
 
 if (
     options.cruncep

--- a/runcase.py
+++ b/runcase.py
@@ -2675,7 +2675,7 @@ for i in range(1, int(options.ninst) + 1):
         output.write(" do_budgets = .false.\n")
     # soil thermal conductivity
     if options.balland_and_arp:
-        output.write(" use_balland_and_arp = .true.")
+        output.write(" use_balland_and_arp = .true.\n")
     # snow options
     if options.dust_snow_mixing:
         output.write(" use_dust_snow_internal_mixing = .true.\n")

--- a/runcase.py
+++ b/runcase.py
@@ -1124,7 +1124,7 @@ else:
     csmdir = options.csmdir
     scriptsdir = csmdir + "/cime/scripts"
 # case directory
-if options.caseroot == "" or (os.path.exists(options.caseroot) == False):
+if options.caseroot == "":
     caseroot = csmdir + "/cime/scripts"
 else:
     caseroot = os.path.abspath(options.caseroot)

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -873,13 +873,27 @@ def runcmd(
     if echo:
         print(cmd)
 
-    result = subprocess.run(
-        cmd,
-        shell=True,
-        check=check,
-        text=True,
-        capture_output=True,
-    )
+    try:
+        result = subprocess.run(
+            cmd,
+            shell=True,
+            check=check,
+            text=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"\n{'='*80}")
+        print(f"ERROR: Command failed with exit code {e.returncode}")
+        print(f"Command: {cmd}")
+        print(f"{'='*80}")
+        if e.stdout:
+            print("STDOUT:")
+            print(e.stdout)
+        if e.stderr:
+            print("STDERR:")
+            print(e.stderr)
+        print(f"{'='*80}\n")
+        sys.exit(e.returncode)
 
     # CIME changes an execution error in case.submit to a warning and continues,
     # so we need to check stderr for the error message and abort if it is present
@@ -1171,12 +1185,19 @@ for row in AFdatareader:
         # ---------------- build base command for all calls to runcase.py -----------------------------
 
         # print year_align, fsplen
+        # For machines without schedulers (docker/ubuntu/mac), let runcase.py submit directly
+        no_submit_flag = ""
+        if not ("docker" in options.machine or "ubuntu" in options.machine or "mac" in options.machine):
+            no_submit_flag = " --no_submit"
+
         basecmd = (
             "python runcase.py --site "
             + site
             + " --ccsm_input "
             + os.path.abspath(ccsm_input)
-            + " --rmold --no_submit --sitegroup "
+            + " --rmold"
+            + no_submit_flag
+            + " --sitegroup "
             + options.sitegroup
             + " --options_log_json "
             + options.options_log_json
@@ -1981,7 +2002,7 @@ for row in AFdatareader:
                 mysubmit_type = ""
             if "ees" in options.machine:
                 mysubmit_type = ""
-            if (sitenum % npernode) == 0:
+            if (sitenum % npernode) == 0 and mysubmit_type != "":
                 mycase_firstsite = ad_case_firstsite
                 if options.noad:
                     mycase_firstsite = fin_case_firstsite
@@ -2480,7 +2501,7 @@ for row in AFdatareader:
 
 
 # Submit PBS scripts for single/multi-site simulations on 1 node
-if not options.no_submit and options.ensemble_file == "":
+if not options.no_submit and options.ensemble_file == "" and mysubmit_type != "":
     for g in range(0, int(groupnum) + 1):
         job_depend_run = ""
         for thiscase in case_list:

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -1037,7 +1037,7 @@ else:
 if options.caseroot == options.runroot:
     caseroot = os.path.abspath(options.caseroot) + "/cime_case_dirs"
     runcmd("mkdir -p " + caseroot)
-elif options.caseroot == "" or not os.path.exists(options.caseroot):
+elif options.caseroot == "":
     caseroot = os.path.abspath(csmdir + "/cime/scripts")
 else:
     caseroot = os.path.abspath(options.caseroot)

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -1041,6 +1041,7 @@ elif options.caseroot == "":
     caseroot = os.path.abspath(csmdir + "/cime/scripts")
 else:
     caseroot = os.path.abspath(options.caseroot)
+    runcmd("mkdir -p " + caseroot)
 
 
 sitenum = 0


### PR DESCRIPTION
321ecb7 closes #23 

9c9defc closes #22. For #22, `caseroot` would silently fall back to scripts directory if caseroot directory didn't exist. This tweaks the conditional logic to not silently fail in this way.