### PR TITLE
Add version checks for OLMT and E3SM repositories

### DIFF
--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -889,6 +889,81 @@ def runcmd(
     return result.returncode
 
 
+def check_git_status():
+    """Check if local branch is up to date with origin remote."""
+    try:
+        # Get current branch
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        branch = result.stdout.strip()
+
+        # Get local and remote HEAD SHAs
+        local_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        remote_sha = subprocess.run(
+            ["git", "rev-parse", f"origin/{branch}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        if local_sha != remote_sha:
+            # Check if local is behind (remote is ancestor of local would mean ahead)
+            behind_check = subprocess.run(
+                ["git", "merge-base", "--is-ancestor", local_sha, remote_sha],
+                capture_output=True,
+            )
+            if behind_check.returncode == 0:
+                return ("behind", branch)
+            else:
+                return ("diverged", branch)
+
+        return ("up-to-date", branch)
+
+    except subprocess.CalledProcessError:
+        # Not in a git repo, or remote doesn't exist, or branch not tracking
+        return (None, None)
+
+
+def handle_outdated_repo(status, branch):
+    """Interactively handle case where repo is behind origin."""
+    print(f"\n{'='*80}")
+    print(f"WARNING: Local branch '{branch}' is {status} relative to origin/{branch}")
+    print(f"{'='*80}\n")
+
+    response = input("Is this intentional? (y/n): ").strip().lower()
+
+    if response == "y":
+        print("Continuing with current local state.\n")
+        return
+
+    has_changes = input("Do you need to keep any local changes? (y/n): ").strip().lower()
+
+    print(f"\n{'='*80}")
+    if has_changes == "y":
+        print("To rebase your local changes on top of origin:")
+        print("  git fetch origin")
+        print(f"  git rebase origin/{branch}")
+        print("\nIf you encounter conflicts, resolve them and run:")
+        print("  git rebase --continue")
+    else:
+        print("To update to match origin (discards local commits):")
+        print("  git fetch origin")
+        print(f"  git reset --hard origin/{branch}")
+    print(f"{'='*80}\n")
+
+    sys.exit(0)
+
+
 # ----------------------------------------------------------
 # define function for pbs submission
 def submit(fname, submit_type="qsub", job_depend=""):
@@ -915,6 +990,13 @@ def submit(fname, submit_type="qsub", job_depend=""):
         thisjob = "0"
         runcmd("rm " + jobinfo, check=False)
     return thisjob
+
+
+# ----------------------------------------------------------
+# Check if local repo is behind origin
+git_status, git_branch = check_git_status()
+if git_status in ("behind", "diverged"):
+    handle_outdated_repo(git_status, git_branch)
 
 
 # ----------------------------------------------------------

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -889,12 +889,18 @@ def runcmd(
     return result.returncode
 
 
-def check_git_status():
-    """Check if local branch is up to date with origin remote."""
+def check_git_status(repo_path=None):
+    """Check if local branch is up to date with origin remote.
+
+    Args:
+        repo_path: Path to git repository. If None, checks current directory.
+    """
+    git_args = ["-C", repo_path] if repo_path else []
+
     try:
         # Get current branch
         result = subprocess.run(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            ["git"] + git_args + ["rev-parse", "--abbrev-ref", "HEAD"],
             capture_output=True,
             text=True,
             check=True,
@@ -903,14 +909,14 @@ def check_git_status():
 
         # Get local and remote HEAD SHAs
         local_sha = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
+            ["git"] + git_args + ["rev-parse", "HEAD"],
             capture_output=True,
             text=True,
             check=True,
         ).stdout.strip()
 
         remote_sha = subprocess.run(
-            ["git", "rev-parse", f"origin/{branch}"],
+            ["git"] + git_args + ["rev-parse", f"origin/{branch}"],
             capture_output=True,
             text=True,
             check=True,
@@ -919,7 +925,7 @@ def check_git_status():
         if local_sha != remote_sha:
             # Check if local is behind (remote is ancestor of local would mean ahead)
             behind_check = subprocess.run(
-                ["git", "merge-base", "--is-ancestor", local_sha, remote_sha],
+                ["git"] + git_args + ["merge-base", "--is-ancestor", local_sha, remote_sha],
                 capture_output=True,
             )
             if behind_check.returncode == 0:
@@ -934,10 +940,71 @@ def check_git_status():
         return (None, None)
 
 
-def handle_outdated_repo(status, branch):
-    """Interactively handle case where repo is behind origin."""
+def check_submodule_status(repo_path):
+    """Check if any submodules are behind origin.
+
+    Args:
+        repo_path: Path to parent git repository
+
+    Returns:
+        List of tuples (submodule_path, status, branch) for out-of-sync submodules
+    """
+    try:
+        # Get list of submodules
+        result = subprocess.run(
+            ["git", "-C", repo_path, "config", "--file", ".gitmodules", "--name-only", "--get-regexp", "path"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        if not result.stdout.strip():
+            return []
+
+        # Extract submodule paths
+        submodule_paths = []
+        for line in result.stdout.strip().split("\n"):
+            # Format is "submodule.<name>.path"
+            name = line.split(".")[1]
+            path_result = subprocess.run(
+                ["git", "-C", repo_path, "config", "--file", ".gitmodules", "--get", f"submodule.{name}.path"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            submodule_paths.append(path_result.stdout.strip())
+
+        # Check each submodule
+        outdated = []
+        for submod_path in submodule_paths:
+            full_path = os.path.join(repo_path, submod_path)
+            if not os.path.exists(full_path):
+                continue
+
+            status, branch = check_git_status(full_path)
+            if status in ("behind", "diverged"):
+                outdated.append((submod_path, status, branch))
+
+        return outdated
+
+    except subprocess.CalledProcessError:
+        # No submodules or not a git repo
+        return []
+
+
+def handle_outdated_repo(status, branch, repo_name="Local", repo_path=None):
+    """Interactively handle case where repo is behind origin.
+
+    Args:
+        status: Git status string ("behind" or "diverged")
+        branch: Branch name
+        repo_name: Human-readable repository name for messages
+        repo_path: Path to repository (for git -C commands). If None, uses cwd.
+    """
     print(f"\n{'='*80}")
-    print(f"WARNING: Local branch '{branch}' is {status} relative to origin/{branch}")
+    print(f"WARNING: {repo_name} branch '{branch}' is {status} relative to origin/{branch}")
+    if repo_path:
+        print(f"Repository: {repo_path}")
     print(f"{'='*80}\n")
 
     response = input("Is this intentional? (y/n): ").strip().lower()
@@ -949,16 +1016,49 @@ def handle_outdated_repo(status, branch):
     has_changes = input("Do you need to keep any local changes? (y/n): ").strip().lower()
 
     print(f"\n{'='*80}")
+    cd_prefix = f"cd {repo_path} && " if repo_path else ""
     if has_changes == "y":
         print("To rebase your local changes on top of origin:")
-        print("  git fetch origin")
-        print(f"  git rebase origin/{branch}")
+        print(f"  {cd_prefix}git fetch origin")
+        print(f"  {cd_prefix}git rebase origin/{branch}")
         print("\nIf you encounter conflicts, resolve them and run:")
-        print("  git rebase --continue")
+        print(f"  {cd_prefix}git rebase --continue")
     else:
         print("To update to match origin (discards local commits):")
-        print("  git fetch origin")
-        print(f"  git reset --hard origin/{branch}")
+        print(f"  {cd_prefix}git fetch origin")
+        print(f"  {cd_prefix}git reset --hard origin/{branch}")
+    print(f"{'='*80}\n")
+
+    sys.exit(0)
+
+
+def handle_outdated_submodules(outdated_submodules, repo_path):
+    """Interactively handle case where submodules are behind origin.
+
+    Args:
+        outdated_submodules: List of tuples (submodule_path, status, branch)
+        repo_path: Path to parent repository
+    """
+    print(f"\n{'='*80}")
+    print(f"WARNING: {len(outdated_submodules)} E3SM submodule(s) out of sync:")
+    for submod_path, status, branch in outdated_submodules:
+        print(f"  - {submod_path}: {status} on {branch}")
+    print(f"Repository: {repo_path}")
+    print(f"{'='*80}\n")
+
+    response = input("Is this intentional? (y/n): ").strip().lower()
+
+    if response == "y":
+        print("Continuing with current submodule state.\n")
+        return
+
+    print(f"\n{'='*80}")
+    print("To update all submodules to match their remotes:")
+    print(f"  cd {repo_path}")
+    print("  git submodule update --remote")
+    print("\nTo update and reset (discards local submodule changes):")
+    print(f"  cd {repo_path}")
+    print("  git submodule foreach 'git fetch origin && git reset --hard origin/$(git rev-parse --abbrev-ref HEAD)'")
     print(f"{'='*80}\n")
 
     sys.exit(0)
@@ -993,10 +1093,10 @@ def submit(fname, submit_type="qsub", job_depend=""):
 
 
 # ----------------------------------------------------------
-# Check if local repo is behind origin
+# Check if local OLMT repo is behind origin
 git_status, git_branch = check_git_status()
 if git_status in ("behind", "diverged"):
-    handle_outdated_repo(git_status, git_branch)
+    handle_outdated_repo(git_status, git_branch, repo_name="OLMT")
 
 
 # ----------------------------------------------------------
@@ -1011,6 +1111,21 @@ if options.csmdir == "":
 elif not os.path.exists(options.csmdir):
     print("Error:  Model root " + options.csmdir + " does not exist.")
     sys.exit(1)
+
+# Check if E3SM/CESM repo is behind origin
+e3sm_git_status, e3sm_git_branch = check_git_status(options.csmdir)
+if e3sm_git_status in ("behind", "diverged"):
+    handle_outdated_repo(
+        e3sm_git_status,
+        e3sm_git_branch,
+        repo_name="E3SM/CESM",
+        repo_path=options.csmdir,
+    )
+
+# Check if E3SM/CESM submodules are behind origin
+outdated_submodules = check_submodule_status(options.csmdir)
+if outdated_submodules:
+    handle_outdated_submodules(outdated_submodules, options.csmdir)
 
 # check whether model named clm or elm
 if os.path.exists(options.csmdir + "/components/elm"):

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -810,6 +810,14 @@ parser.add_option(
     action="store_true",
     help="Do not execute commands",
 )
+parser.add_option(
+    "--skip_version_check",
+    dest="skip_version_check",
+    default=False,
+    action="store_true",
+    help="Skip checking whether OLMT/E3SM repos are behind their remotes "
+    "(useful for local development where being ahead of origin is intentional)",
+)
 (options, args) = parser.parse_args()
 
 
@@ -889,55 +897,116 @@ def runcmd(
     return result.returncode
 
 
+# Statuses from check_git_status that warrant interactive resolution because the
+# local tree is behind or has diverged from origin.
+ACTIONABLE_GIT_STATUSES = ("behind", "diverged")
+
+# Statuses where a comparison against origin could not be made (or where being
+# out of sync is expected, e.g. "ahead" during local development). These are
+# surfaced as non-fatal warnings rather than silently ignored.
+GIT_SKIP_REASONS = {
+    "ahead": "local branch is ahead of origin (unpushed commits)",
+    "detached": "HEAD is detached; no branch to compare against origin",
+    "no-commits": "repository has no commits yet",
+    "no-remote": "no 'origin' remote is configured",
+    "no-upstream-branch": "origin has no branch with this name",
+    "not-a-git-repo": "path is not a git repository",
+}
+
+
 def check_git_status(repo_path=None):
     """Check if local branch is up to date with origin remote.
 
     Args:
         repo_path: Path to git repository. If None, checks current directory.
+
+    Returns:
+        Tuple (status, branch). ``status`` is one of:
+          - "up-to-date": local matches origin/<branch>
+          - "behind":     local is an ancestor of origin/<branch>
+          - "ahead":      origin/<branch> is an ancestor of local (unpushed commits)
+          - "diverged":   neither is an ancestor of the other
+          - "not-a-git-repo":     repo_path is not inside a git work tree
+          - "detached":           HEAD is detached (no branch to compare)
+          - "no-commits":         repo has no commits yet (unborn HEAD)
+          - "no-remote":          no "origin" remote is configured
+          - "no-upstream-branch": origin exists but has no branch of this name
+        ``branch`` is the branch name where known, otherwise None.
     """
     git_args = ["-C", repo_path] if repo_path else []
 
-    try:
-        # Get current branch
-        result = subprocess.run(
-            ["git"] + git_args + ["rev-parse", "--abbrev-ref", "HEAD"],
+    # Confirm this is a git work tree first; a non-zero exit means it isn't.
+    inside_tree = subprocess.run(
+        ["git"] + git_args + ["rev-parse", "--is-inside-work-tree"],
+        capture_output=True,
+        text=True,
+    )
+    if inside_tree.returncode != 0:
+        return ("not-a-git-repo", None)
+
+    # Get the current branch via symbolic-ref: it names the branch even on an
+    # unborn HEAD (no commits yet) and returns non-zero only for detached HEAD.
+    branch_result = subprocess.run(
+        ["git"] + git_args + ["symbolic-ref", "-q", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    if branch_result.returncode != 0:
+        return ("detached", None)
+    branch = branch_result.stdout.strip()
+
+    # Get local HEAD SHA. Failure (unborn branch) means no commits yet.
+    local_result = subprocess.run(
+        ["git"] + git_args + ["rev-parse", "--verify", "-q", "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    if local_result.returncode != 0:
+        return ("no-commits", branch)
+    local_sha = local_result.stdout.strip()
+
+    # Get remote-tracking SHA. Failure means we can't compare; figure out why.
+    remote_result = subprocess.run(
+        ["git"] + git_args + ["rev-parse", f"origin/{branch}"],
+        capture_output=True,
+        text=True,
+    )
+    if remote_result.returncode != 0:
+        remotes = subprocess.run(
+            ["git"] + git_args + ["remote"],
             capture_output=True,
             text=True,
-            check=True,
-        )
-        branch = result.stdout.strip()
+        ).stdout.split()
+        if "origin" not in remotes:
+            return ("no-remote", branch)
+        return ("no-upstream-branch", branch)
+    remote_sha = remote_result.stdout.strip()
 
-        # Get local and remote HEAD SHAs
-        local_sha = subprocess.run(
-            ["git"] + git_args + ["rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.strip()
-
-        remote_sha = subprocess.run(
-            ["git"] + git_args + ["rev-parse", f"origin/{branch}"],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.strip()
-
-        if local_sha != remote_sha:
-            # Check if local is behind (remote is ancestor of local would mean ahead)
-            behind_check = subprocess.run(
-                ["git"] + git_args + ["merge-base", "--is-ancestor", local_sha, remote_sha],
-                capture_output=True,
-            )
-            if behind_check.returncode == 0:
-                return ("behind", branch)
-            else:
-                return ("diverged", branch)
-
+    if local_sha == remote_sha:
         return ("up-to-date", branch)
 
-    except subprocess.CalledProcessError:
-        # Not in a git repo, or remote doesn't exist, or branch not tracking
-        return (None, None)
+    # local is an ancestor of remote -> behind; remote ancestor of local -> ahead.
+    local_ancestor_of_remote = (
+        subprocess.run(
+            ["git"] + git_args + ["merge-base", "--is-ancestor", local_sha, remote_sha],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+    if local_ancestor_of_remote:
+        return ("behind", branch)
+
+    remote_ancestor_of_local = (
+        subprocess.run(
+            ["git"] + git_args + ["merge-base", "--is-ancestor", remote_sha, local_sha],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+    if remote_ancestor_of_local:
+        return ("ahead", branch)
+
+    return ("diverged", branch)
 
 
 def check_submodule_status(repo_path):
@@ -947,7 +1016,9 @@ def check_submodule_status(repo_path):
         repo_path: Path to parent git repository
 
     Returns:
-        List of tuples (submodule_path, status, branch) for out-of-sync submodules
+        List of tuples (submodule_path, status, branch) for every submodule
+        whose status is not "up-to-date". Callers use evaluate_submodule_status
+        to split these into actionable divergence vs. non-fatal skip warnings.
     """
     try:
         # Get list of submodules
@@ -982,7 +1053,7 @@ def check_submodule_status(repo_path):
                 continue
 
             status, branch = check_git_status(full_path)
-            if status in ("behind", "diverged"):
+            if status != "up-to-date":
                 outdated.append((submod_path, status, branch))
 
         return outdated
@@ -1064,6 +1135,52 @@ def handle_outdated_submodules(outdated_submodules, repo_path):
     sys.exit(0)
 
 
+def evaluate_repo_status(status, branch, repo_name="Local", repo_path=None):
+    """Route a check_git_status result to the appropriate handling.
+
+    - behind/diverged: interactive resolution via handle_outdated_repo (may exit).
+    - up-to-date: no output.
+    - anything else: a non-fatal WARNING so the reason a version check could not
+      be performed is visible instead of being silently swallowed.
+
+    Args:
+        status: Status string returned by check_git_status.
+        branch: Branch name (may be None).
+        repo_name: Human-readable repository name for messages.
+        repo_path: Path to repository (for messages). If None, uses cwd.
+    """
+    if status in ACTIONABLE_GIT_STATUSES:
+        handle_outdated_repo(status, branch, repo_name=repo_name, repo_path=repo_path)
+        return
+
+    if status == "up-to-date":
+        return
+
+    reason = GIT_SKIP_REASONS.get(status, f"unrecognized git status '{status}'")
+    location = f" ({repo_path})" if repo_path else ""
+    print(f"WARNING: version check skipped for {repo_name}{location}: {reason}.")
+
+
+def evaluate_submodule_status(outdated_submodules, repo_path):
+    """Route check_submodule_status results: warn about submodules that could not
+    be checked, then interactively handle any that are behind/diverged.
+
+    Args:
+        outdated_submodules: List of (submodule_path, status, branch) for every
+            submodule whose status is not "up-to-date".
+        repo_path: Path to the parent repository.
+    """
+    actionable = [s for s in outdated_submodules if s[1] in ACTIONABLE_GIT_STATUSES]
+    skipped = [s for s in outdated_submodules if s[1] not in ACTIONABLE_GIT_STATUSES]
+
+    for submod_path, status, _branch in skipped:
+        reason = GIT_SKIP_REASONS.get(status, f"unrecognized git status '{status}'")
+        print(f"WARNING: version check skipped for submodule '{submod_path}': {reason}.")
+
+    if actionable:
+        handle_outdated_submodules(actionable, repo_path)
+
+
 # ----------------------------------------------------------
 # define function for pbs submission
 def submit(fname, submit_type="qsub", job_depend=""):
@@ -1094,9 +1211,9 @@ def submit(fname, submit_type="qsub", job_depend=""):
 
 # ----------------------------------------------------------
 # Check if local OLMT repo is behind origin
-git_status, git_branch = check_git_status()
-if git_status in ("behind", "diverged"):
-    handle_outdated_repo(git_status, git_branch, repo_name="OLMT")
+if not options.skip_version_check:
+    git_status, git_branch = check_git_status()
+    evaluate_repo_status(git_status, git_branch, repo_name="OLMT")
 
 
 # ----------------------------------------------------------
@@ -1112,20 +1229,18 @@ elif not os.path.exists(options.csmdir):
     print("Error:  Model root " + options.csmdir + " does not exist.")
     sys.exit(1)
 
-# Check if E3SM/CESM repo is behind origin
-e3sm_git_status, e3sm_git_branch = check_git_status(options.csmdir)
-if e3sm_git_status in ("behind", "diverged"):
-    handle_outdated_repo(
+# Check if E3SM/CESM repo (and its submodules) are behind origin
+if not options.skip_version_check:
+    e3sm_git_status, e3sm_git_branch = check_git_status(options.csmdir)
+    evaluate_repo_status(
         e3sm_git_status,
         e3sm_git_branch,
         repo_name="E3SM/CESM",
         repo_path=options.csmdir,
     )
 
-# Check if E3SM/CESM submodules are behind origin
-outdated_submodules = check_submodule_status(options.csmdir)
-if outdated_submodules:
-    handle_outdated_submodules(outdated_submodules, options.csmdir)
+    outdated_submodules = check_submodule_status(options.csmdir)
+    evaluate_submodule_status(outdated_submodules, options.csmdir)
 
 # check whether model named clm or elm
 if os.path.exists(options.csmdir + "/components/elm"):

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -1024,7 +1024,7 @@ def handle_outdated_repo(status, branch, repo_name="Local", repo_path=None):
         print("\nIf you encounter conflicts, resolve them and run:")
         print(f"  {cd_prefix}git rebase --continue")
     else:
-        print("To update to match origin (discards local commits):")
+        print("To update to match origin (discards local commits and uncommitted changes):")
         print(f"  {cd_prefix}git fetch origin")
         print(f"  {cd_prefix}git reset --hard origin/{branch}")
     print(f"{'='*80}\n")


### PR DESCRIPTION
## Summary

- Adds git status checks for OLMT, E3SM/CESM main repo, and E3SM submodules
- Warns users when local branches are behind or diverged from origin
- Prompts for user confirmation with update commands before continuing

## Details

**OLMT check** (commit 05e5a82):
- Runs at startup before model_root validation
- Checks if local OLMT branch behind/diverged from origin
- Interactive prompt with rebase/reset instructions

**E3SM check** (commit d3173ad):
- Runs after --model_root validated
- Extended check_git_status() to accept repo_path parameter
- Extended handle_outdated_repo() to accept repo_name + repo_path for clarity
- Checks E3SM/CESM main repo git status
- Checks all E3SM submodules via new check_submodule_status()
- Interactive prompts with repo-specific update commands

Fixes #24