### PR TITLE
Hardcode mct driver when calling create_newcase

### DIFF
--- a/docs/runcase.rst
+++ b/docs/runcase.rst
@@ -429,9 +429,16 @@ CIME Integration
 
 Line 1871–1895. Constructs the ``create_newcase`` command with::
 
-    ./create_newcase --case <casedir> --mach <machine> --compset <compset> --res <res> \
+    ./create_newcase --case <casedir> --driver mct --mach <machine> --compset <compset> --res <res> \
                      --mpilib <mpilib> --walltime <timestr> --handle-preexisting-dirs u \
                      [--run-unsupported] [--project <project>] [--compiler <compiler>]
+
+Note that as of July 2026, the use of the MCT driver is hardcoded.  This is to avoid transitioning
+to the MOAB driver that E3SM made default in June 2026.  The E3SM project tested the MOAB driver
+thoroughly to ensure it behaves bit-for-bit with the MCT driver, but the MOAB driver is not
+compiled as part of the E3SM build process and is instead required to pre-exist as a compiled
+library.  This complication is undesirable for OLMT usage.  This decision may be revisited in
+the future if MOAB features are required or MCT support stops.
 
 ``xmlchange`` Variables
 ------------------------

--- a/docs/runcase.rst
+++ b/docs/runcase.rst
@@ -429,16 +429,16 @@ CIME Integration
 
 Line 1871–1895. Constructs the ``create_newcase`` command with::
 
-    ./create_newcase --case <casedir> --driver mct --mach <machine> --compset <compset> --res <res> \
+    ./create_newcase --case <casedir> --driver <driver> --mach <machine> --compset <compset> --res <res> \
                      --mpilib <mpilib> --walltime <timestr> --handle-preexisting-dirs u \
                      [--run-unsupported] [--project <project>] [--compiler <compiler>]
 
-Note that as of July 2026, the use of the MCT driver is hardcoded.  This is to avoid transitioning
-to the MOAB driver that E3SM made default in June 2026.  The E3SM project tested the MOAB driver
-thoroughly to ensure it behaves bit-for-bit with the MCT driver, but the MOAB driver is not
-compiled as part of the E3SM build process and is instead required to pre-exist as a compiled
-library.  This complication is undesirable for OLMT usage.  This decision may be revisited in
-the future if MOAB features are required or MCT support stops.
+Note that as of June 2026, E3SM made MOAB the default coupler. The E3SM project tested
+the MOAB driver thoroughly to ensure it behaves bit-for-bit with the MCT driver, but the
+MOAB driver is not compiled as part of the E3SM build process and is instead required
+to pre-exist as a compiled library.  This complication is undesirable for OLMT usage, so
+we made MCT the default driver when running from OLMT for now.  This decision may be
+revisited in the future if MOAB features are required or MCT support stops.
 
 ``xmlchange`` Variables
 ------------------------

--- a/runcase.py
+++ b/runcase.py
@@ -1871,6 +1871,7 @@ timestr = (
 cmd = (
     "./create_newcase --case "
     + casedir
+    + " --driver mct "
     + " --mach "
     + options.machine
     + " --compset "

--- a/runcase.py
+++ b/runcase.py
@@ -178,6 +178,14 @@ parser.add_option(
     help="mpi library (openmpi, mpich, ibm, mpi-serial)",
 )
 parser.add_option(
+    "--driver",
+    dest="driver",
+    default="mct",
+    type="choice",
+    choices=("mct", "moab"),
+    help="Coupling driver to use: mct or moab (default: %default)",
+)
+parser.add_option(
     "--diags",
     dest="diags",
     default=False,
@@ -1871,7 +1879,9 @@ timestr = (
 cmd = (
     "./create_newcase --case "
     + casedir
-    + " --driver mct "
+    + " --driver "
+    + options.driver
+    + " "
     + " --mach "
     + options.machine
     + " --compset "

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -134,6 +134,14 @@ parser.add_option(
     help="mpi library (openmpi, mpich, ibm, mpi-serial)",
 )
 parser.add_option(
+    "--driver",
+    dest="driver",
+    default="mct",
+    type="choice",
+    choices=("mct", "moab"),
+    help="Coupling driver to use: mct or moab (default: %default)",
+)
+parser.add_option(
     "--debugq",
     dest="debug",
     default=False,
@@ -1327,6 +1335,7 @@ for row in AFdatareader:
         if options.compiler != "":
             basecmd = basecmd + " --compiler " + options.compiler
         basecmd = basecmd + " --mpilib " + options.mpilib
+        basecmd = basecmd + " --driver " + options.driver
         basecmd = basecmd + " --pio_version " + options.pio_version
         basecmd = basecmd + " --caseroot " + caseroot
         basecmd = basecmd + " --runroot " + runroot


### PR DESCRIPTION
E3SM recently switched the default driver from MCT to MOAB.  Even though the MOAB driver was thoroughly tested to be BFC with MCT, the way MOAB is used in E3SM, it must be a pre-compiled library and does not get compiled as part of the build.  Because we don't want to require MOAB compilation on every platform that OLMT is run, and because we don't require any MOAB features at present, for the foreseaable future we prefer to use MCT.  If MOAB features become needed or MCT support is dropped in E3SM, this can be revisited.  By hardcoding this now, OLMT will continue to work seamlessly with new versions of E3SM that have been switched to default to MOAB.