### PR TITLE
Add squareomfracFalse option

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -6,3 +6,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/ruff-action@v3
+        with:
+          # Pin ruff version to match development environment
+          # Update this when upgrading local ruff version in requirements.txt
+          # or when new ruff rules are addressed in the codebase
+          version: "0.15.17"

--- a/docs/global_fullrun.rst
+++ b/docs/global_fullrun.rst
@@ -184,6 +184,11 @@ Topography
 - ``--topounits`` — enable topographic units (> 1)
 - ``--topounits_atmdownscale`` — use atmospheric downscaling with topounits
 
+Soil Physics
+^^^^^^^^^^^^
+
+- ``--no_squareomfrac`` — disable square scaling of organic matter fraction in soil thermal conductivity
+
 Snow/Albedo
 ^^^^^^^^^^^
 

--- a/docs/runcase.rst
+++ b/docs/runcase.rst
@@ -349,6 +349,8 @@ NGEE Arctic Options
 
    * - Option
      - Description
+   * - ``--no_squareomfrac``
+     - Disable square scaling of organic matter fraction in soil thermal conductivity
    * - ``--topounits_atmdownscale``
      - Use atmospheric downscaling in topounits
    * - ``--topounits_raddownscale``

--- a/docs/site_fullrun.rst
+++ b/docs/site_fullrun.rst
@@ -407,6 +407,11 @@ Model Output Options
 NGEE Arctic Options
 -------------------
 
+**Soil Options**
+
+``--no_squareomfrac``
+  Disable square scaling of organic matter fraction in soil thermal conductivity. Default: False.
+
 **Snow Options**
 
 ``--dust_snow_mixing``

--- a/global_fullrun.py
+++ b/global_fullrun.py
@@ -494,10 +494,10 @@ parser.add_option(
 )
 # soil options:
 parser.add_option(
-    "--squareomfracFalse",
-    dest="squareomfracFalse",
+    "--no_squareomfrac",
+    dest="no_squareomfrac",
     default=False,
-    help="Set squareomfrac to false",
+    help="Disable square scaling of organic matter fraction in soil thermal conductivity",
     action="store_true",
 )
 # snow options:
@@ -1025,8 +1025,8 @@ if options.topounits:
     basecmd = basecmd + " --topounits"
 if options.topounits_atmdownscale:
     basecmd = basecmd + " --topounits_atmdownscale"
-if options.squareomfracFalse:
-    basecmd = basecmd + " --squareomfracFalse"
+if options.no_squareomfrac:
+    basecmd = basecmd + " --no_squareomfrac"
 if options.dust_snow_mixing:
     basecmd = basecmd + " --dust_snow_mixing"
 if options.no_snicar_ad:

--- a/global_fullrun.py
+++ b/global_fullrun.py
@@ -492,6 +492,14 @@ parser.add_option(
     help="Use atmospheric downscaling in topounits",
     action="store_true",
 )
+# soil options:
+parser.add_option(
+    "--squareomfracFalse",
+    dest="squareomfracFalse",
+    default=False,
+    help="Set squareomfrac to false",
+    action="store_true",
+)
 # snow options:
 parser.add_option(
     "--dust_snow_mixing",
@@ -1017,6 +1025,8 @@ if options.topounits:
     basecmd = basecmd + " --topounits"
 if options.topounits_atmdownscale:
     basecmd = basecmd + " --topounits_atmdownscale"
+if options.squareomfracFalse:
+    basecmd = basecmd + " --squareomfracFalse"
 if options.dust_snow_mixing:
     basecmd = basecmd + " --dust_snow_mixing"
 if options.no_snicar_ad:

--- a/runcase.py
+++ b/runcase.py
@@ -947,6 +947,14 @@ parser.add_option(
     help="Downscale radiation input to topounits",
     action="store_true",
 )
+# soil:
+parser.add_option(
+    "--squareomfracFalse",
+    dest="squareomfracFalse",
+    default=False,
+    help="Set squareomfrac to false",
+    action="store_true",
+)
 # snow options:
 parser.add_option(
     "--dust_snow_mixing",
@@ -2688,6 +2696,8 @@ for i in range(1, int(options.ninst) + 1):
     # soil thermal conductivity
     if options.soil_thermal_conductivity_model != "farouki":
         output.write(f" soil_thermal_conductivity_model = '{options.soil_thermal_conductivity_model}'\n")
+    if options.squareomfracFalse:
+        output.write(" squareomfrac = .false.\n")
     # snow options
     if options.dust_snow_mixing:
         output.write(" use_dust_snow_internal_mixing = .true.\n")

--- a/runcase.py
+++ b/runcase.py
@@ -947,12 +947,12 @@ parser.add_option(
     help="Downscale radiation input to topounits",
     action="store_true",
 )
-# soil:
+# soil options:
 parser.add_option(
-    "--squareomfracFalse",
-    dest="squareomfracFalse",
+    "--no_squareomfrac",
+    dest="no_squareomfrac",
     default=False,
-    help="Set squareomfrac to false",
+    help="Disable square scaling of organic matter fraction in soil thermal conductivity",
     action="store_true",
 )
 # snow options:
@@ -2696,7 +2696,7 @@ for i in range(1, int(options.ninst) + 1):
     # soil thermal conductivity
     if options.soil_thermal_conductivity_model != "farouki":
         output.write(f" soil_thermal_conductivity_model = '{options.soil_thermal_conductivity_model}'\n")
-    if options.squareomfracFalse:
+    if options.no_squareomfrac:
         output.write(" squareomfrac = .false.\n")
     # snow options
     if options.dust_snow_mixing:

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -696,6 +696,14 @@ parser.add_option(
 # --------------------
 # NGEE Arctic Options
 # --------------------
+# soil options
+parser.add_option(
+    "--squareomfracFalse",
+    dest="squareomfracFalse",
+    default=False,
+    help="Set squareomfrac to false",
+    action="store_true",
+)
 # snow options
 parser.add_option(
     "--dust_snow_mixing",
@@ -1677,6 +1685,9 @@ for row in AFdatareader:
             basecmd = basecmd + " --project " + myproject
         if options.domainfile != "":
             basecmd = basecmd + " --domainfile " + options.domainfile
+        # soil
+        if options.squareomfracFalse:
+            basecmd = basecmd + " --squareomfracFalse"
         # snow opts
         if options.dust_snow_mixing:
             basecmd = basecmd + " --dust_snow_mixing"

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -698,10 +698,10 @@ parser.add_option(
 # --------------------
 # soil options
 parser.add_option(
-    "--squareomfracFalse",
-    dest="squareomfracFalse",
+    "--no_squareomfrac",
+    dest="no_squareomfrac",
     default=False,
-    help="Set squareomfrac to false",
+    help="Disable square scaling of organic matter fraction in soil thermal conductivity",
     action="store_true",
 )
 # snow options
@@ -1686,8 +1686,8 @@ for row in AFdatareader:
         if options.domainfile != "":
             basecmd = basecmd + " --domainfile " + options.domainfile
         # soil
-        if options.squareomfracFalse:
-            basecmd = basecmd + " --squareomfracFalse"
+        if options.no_squareomfrac:
+            basecmd = basecmd + " --no_squareomfrac"
         # snow opts
         if options.dust_snow_mixing:
             basecmd = basecmd + " --dust_snow_mixing"


### PR DESCRIPTION
Add flag in OLMT to control the squareomfrac namelist flag in ELM. If an OLMT run includes "--squareomfracFalse", then squareomfrac in ELM is changed to False (from the ELM default of True).