### PR TITLE
Add chicoma-cpu machine support to global_fullrun

### DIFF
--- a/global_fullrun.py
+++ b/global_fullrun.py
@@ -711,6 +711,9 @@ elif "anvil" in options.machine:
     ccsm_input = "/home/ccsm-data/inputdata"
 elif "compy" in options.machine:
     ccsm_input = "/compyfs/inputdata"
+elif "chicoma" in options.machine:
+    # Mirrors DIN_LOC_ROOT in the CIME chicoma-cpu machine file.
+    ccsm_input = "/lustre/scratch5/" + getpass.getuser() + "/inputdata"
 
 if options.makepointdata_only:  # don't configure/build/run model
     options.noad = False
@@ -729,6 +732,8 @@ if options.compiler == "":
         options.compiler = "gnu"
     if options.machine == "compy":
         options.compiler = "intel"
+    if "chicoma" in options.machine:
+        options.compiler = "gnu"
     if options.machine == "docker":
         options.compiler = "gnu"
 
@@ -742,6 +747,8 @@ if options.mpilib == "":
         options.mpilib = "mvapich"
     elif "compy" in options.machine:
         options.mpilib = "impi"
+    elif "chicoma" in options.machine:
+        options.mpilib = "mpich"
     elif "docker" in options.machine:
         options.mpilib = "openmpi"
 
@@ -820,6 +827,9 @@ if options.runroot == "":
         runroot = "/lcrc/group/acme/" + myuser
     elif "compy" in options.machine:
         runroot = "/compyfs/" + myuser + "/e3sm_scratch"
+    elif "chicoma" in options.machine:
+        # Mirrors CIME_OUTPUT_ROOT in the CIME chicoma-cpu machine file.
+        runroot = "/lustre/scratch5/" + myuser + "/E3SM/scratch/" + options.machine
     else:
         runroot = csmdir + "/run"
 else:

--- a/global_fullrun.py
+++ b/global_fullrun.py
@@ -734,7 +734,8 @@ if options.compiler == "":
         options.compiler = "intel"
     if "chicoma" in options.machine:
         options.compiler = "gnu"
-    if options.machine == "docker":
+    if "docker" in options.machine:
+        # Applies to "docker" and hybrid variants like "docker-chicoma-cpu"
         options.compiler = "gnu"
 
 # default MPIlibs

--- a/runcase.py
+++ b/runcase.py
@@ -1101,6 +1101,13 @@ elif "chrysalis" in options.machine:
     ppn = 64
 elif "pm-cpu" in options.machine:
     ppn = 128
+elif "chicoma" in options.machine:
+    # AMD Rome EPYC 7H12: 128 physical cores/node.  The CIME machine file
+    # advertises MAX_TASKS_PER_NODE=256 (2 hardware threads/core), but ELM
+    # performs poorly with multithreading, so cap at one MPI task per physical
+    # core.  Setting ppn=128 makes runcase set both MAX_TASKS_PER_NODE and
+    # MAX_MPITASKS_PER_NODE to 128 below, disabling the extra thread slots.
+    ppn = 128
 elif "docker" in options.machine:
     ppn = 4
 if options.ensemble_file == "":

--- a/runcase.py
+++ b/runcase.py
@@ -1101,6 +1101,11 @@ elif "chrysalis" in options.machine:
     ppn = 64
 elif "pm-cpu" in options.machine:
     ppn = 128
+elif "docker-chicoma-cpu" in options.machine:
+    # Hybrid docker/chicoma-cpu: container-based testing with chicoma's 128-core
+    # node config. Uses docker's local paths and no-scheduler behavior but
+    # chicoma-cpu's parallelism to test chicoma-scale runs in containers.
+    ppn = 128
 elif "chicoma" in options.machine:
     # AMD Rome EPYC 7H12: 128 physical cores/node.  The CIME machine file
     # advertises MAX_TASKS_PER_NODE=256 (2 hardware threads/core), but ELM

--- a/site_fullrun.py
+++ b/site_fullrun.py
@@ -845,7 +845,7 @@ if options.tempdir:
     tempdir = os.path.abspath(options.tempdir)
 else:
     tempdir = os.path.abspath(
-        "./temp/run_%d_%d" % (os.getpid(), int(time.time() * 1000))
+        f"./temp/run_{os.getpid()}_{int(time.time() * 1000)}"
     )
 os.makedirs(tempdir, exist_ok=True)
 
@@ -1321,6 +1321,9 @@ elif "anvil" in options.machine or "chrysalis" in options.machine:
     ccsm_input = "/home/ccsm-data/inputdata"
 elif "compy" in options.machine:
     ccsm_input = "/compyfs/inputdata/"
+elif "chicoma" in options.machine:
+    # Mirrors DIN_LOC_ROOT in the CIME chicoma-cpu machine file.
+    ccsm_input = "/lustre/scratch5/" + getpass.getuser() + "/inputdata"
 elif "docker" in options.machine:
     ccsm_input = "/home/e3smuser/inputdata"
 
@@ -1357,6 +1360,10 @@ if options.runroot == "" or not os.path.exists(options.runroot):
         myproject = "e3sm"
     elif "compy" in options.machine:
         runroot = "/compyfs/" + myuser + "/e3sm_scratch"
+        myproject = "e3sm"
+    elif "chicoma" in options.machine:
+        # Mirrors CIME_OUTPUT_ROOT in the CIME chicoma-cpu machine file.
+        runroot = "/lustre/scratch5/" + myuser + "/E3SM/scratch/" + options.machine
         myproject = "e3sm"
     else:
         runroot = csmdir + "/run"
@@ -1580,7 +1587,7 @@ for row in AFdatareader:
             basecmd = basecmd + " --marsh"
         if options.tide_components_file != "":
             basecmd = (
-                basecmd + " --tide_components_file %s" % options.tide_components_file
+                basecmd + f" --tide_components_file {options.tide_components_file}"
             )
         if float(options.lai) >= 0:
             basecmd = basecmd + " --lai " + str(options.lai)


### PR DESCRIPTION
## Summary

Enables `global_fullrun.py` and `site_fullrun.py` on chicoma (LANL): slurm scheduler, 16 h wallclock queue, AMD Rome EPYC 7H12 nodes (128 physical cores/node). E3SM already defines `chicoma-cpu`/`chicoma-gpu` in CIME, so the batch system, queue/walltime limits, `srun` launch, and node-count derivation come for free — these changes are the small OLMT-side gaps.

Also adds a `docker-chicoma-cpu` machine variant for testing chicoma-scale parallel runs (128 cores/node) in containerized environments.

Use `--machine chicoma-cpu` or `--machine docker-chicoma-cpu`.

## Changes

### chicoma-cpu support

- **`runcase.py`** — set cores-per-node to 128 for chicoma. This is the key change: without it `ppn` defaults to 1, and `runcase.py` would overwrite CIME's `MAX_MPITASKS_PER_NODE` with 1 (one MPI task per node). Capping at 128 also sets `MAX_TASKS_PER_NODE=128`, pinning one MPI task per physical core — ELM performs poorly with multithreading, so the machine file's advertised 256 hardware threads/node are intentionally not used.
- **`global_fullrun.py`** — chicoma defaults for `--compiler` (`gnu`), `--mpilib` (`mpich`), `ccsm_input` (`/lustre/scratch5/$USER/inputdata`), and `runroot` (`/lustre/scratch5/$USER/E3SM/scratch/chicoma-cpu`), mirroring the CIME `chicoma-cpu` machine file. All remain overridable via command-line flags.
- **`site_fullrun.py`** — same `ccsm_input` and `runroot` defaults as global_fullrun. Compiler/mpilib defaults not needed (site_fullrun doesn't have those blocks); ppn inherited from runcase.py.

### docker-chicoma-cpu variant

- **`runcase.py`** — explicit `docker-chicoma-cpu` ppn=128 check placed **before** general `"docker" in options.machine` check, so it matches first and gets chicoma's 128-core config instead of docker's ppn=4.
- **`global_fullrun.py`** — changed docker compiler check from `==` to substring match (`"docker" in options.machine`), so `docker-chicoma-cpu` inherits docker's `compiler=gnu`.
- **Result:** hybrid machine that uses docker's characteristics (local container paths like `/home/e3smuser/inputdata`, no batch scheduler, openmpi, direct submission) but with chicoma's 128-core parallelism — suitable for testing large-scale runs in containers without HPC infrastructure.

## Multi-node

Supported with no further changes: set `--np` to `nodes × 128` (e.g. 512 = 4 nodes, 1024 = 8, 1280 = 10, 1536 = 12). CIME derives `--nodes` from `NTASKS / MAX_MPITASKS_PER_NODE` and the batch wrapper copies that directive through. Useful task count is bounded by active land gridcells in the domain.

## Usage notes

### chicoma-cpu
- `--project` is required (`PROJECT_REQUIRED=TRUE` on chicoma-cpu).
- Pass `--walltime 16` (default is 24, above the queue max) and size `--runblock` so each chained segment finishes under 16 h.

### docker-chicoma-cpu
- No `--project` required (no scheduler).
- Uses local paths: `ccsm_input=/home/e3smuser/inputdata`, `runroot=<csmdir>/run`.
- Suitable for testing 128-core parallel decompositions in containerized CI or local environments.

## Testing

Lint only (`ruff check` — no new errors introduced). Not yet run end-to-end on chicoma.